### PR TITLE
Add APIClient type to test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # pep484 stubs for Django REST framework
 
-[![Build Status](https://travis-ci.org/mkurnikov/djangorestframework-stubs.svg?branch=master)](https://travis-ci.org/mkurnikov/djangorestframework-stubs)
+[![Build Status](https://travis-ci.com/typeddjango/djangorestframework-stubs.svg?branch=master)](https://travis-ci.com/typeddjango/djangorestframework-stubs)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 
 

--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -60,8 +60,16 @@ class APIClient(DjangoClient):
         **extra: Any
     ) -> Response: ...
 
-class APITransactionTestCase(testcases.TransactionTestCase): ...
-class APITestCase(testcases.TestCase): ...
-class APISimpleTestCase(testcases.SimpleTestCase): ...
-class APILiveServerTestCase(testcases.LiveServerTestCase): ...
+class APITransactionTestCase(testcases.TransactionTestCase):
+    client: APIClient
+
+class APITestCase(testcases.TestCase):
+    client: APIClient
+
+class APISimpleTestCase(testcases.SimpleTestCase):
+    client: APIClient
+
+class APILiveServerTestCase(testcases.LiveServerTestCase):
+    client: APIClient
+
 class URLPatternsTestCase(testcases.SimpleTestCase): ...


### PR DESCRIPTION
`client_class` is explicitly set to `APIClient` in `rest_framework/test.py`, but I suppose that the client is created dynamically, thus drf-stubs have no idea that it should be an `APIClient` and not a `Client` warning me about `response.data` and `client.force_authenticate`.