### PR TITLE
Allow dependency on mypy 0.730

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open('README.md', 'r') as f:
     readme = f.read()
 
 dependencies = [
-    'mypy>=0.720,<0.730',
+    'mypy>=0.720,<=0.730',
     'django-stubs>=1.0.0',
     'typing-extensions'
 ]


### PR DESCRIPTION
This is the latest mypy as of this time. Breaking changes only seem to involve the output format:
http://mypy-lang.blogspot.com/2019/09/mypy-730-released.html

Fixes #35.