### PR TITLE
Allow Mapping method names as field names

### DIFF
--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -111,7 +111,7 @@ class SerializerMetaclass(type):
 
 def as_serializer_error(exc: Exception) -> Dict[str, List[ErrorDetail]]: ...
 
-class Serializer(BaseSerializer, Mapping[str, BoundField]):
+class Serializer(BaseSerializer):
     @property
     def fields(self) -> Dict[str, Field]: ...
     @property


### PR DESCRIPTION
This PR addresses an issue where field names conflicts with method names of `Mapping`, which `Serializer` extends.

If a serializer has a field named `keys`, `values`, `items` or `get`, an **assignment** error is thrown by mypy.

**Error example**:
```py
# test.py
from rest_framework.serializers import Serializer, CharField


class MySerializer(Serializer):
    items = CharField()  # [assignment] error
```
```console
$ mypy test.py
test.py:6: error: Incompatible types in assignment (expression has type "CharField", base class "Mapping" defined the type as "Callable[[Mapping[str, BoundField]], AbstractSet[str]]")
```

This is solved by dropping `Mapping` inheritance. DRF does not fully implement Mapping anyways.