### PR TITLE
Add `Meta` attribute to `ModelSerializer` (#69)

### DIFF
--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -12,6 +12,7 @@ from typing import (
     NoReturn,
     MutableMapping,
     Iterator,
+    Union,
 )
 
 from rest_framework.fields import (
@@ -149,6 +150,13 @@ class ModelSerializer(Serializer):
     serializer_url_field: Type[RelatedField] = ...
     serializer_choice_field: Type[Field] = ...
     url_field_name: Optional[str] = ...
+    class Meta:
+        model: Type[Model]
+        fields: Optional[Union[Sequence[str], str]]
+        read_only_fields: Optional[Sequence[str]]
+        exclude: Optional[Sequence[str]]
+        depth: Optional[int]
+        extra_kwargs: Dict[str, Dict[str, Any]]
     def get_field_names(self, declared_fields: Mapping[str, Field], info: FieldInfo) -> List[str]: ...
     def get_default_field_names(self, declared_fields: Mapping[str, Field], model_info: FieldInfo) -> List[str]: ...
     def build_field(

--- a/test-data/typecheck/test_serializers.yml
+++ b/test-data/typecheck/test_serializers.yml
@@ -9,3 +9,29 @@
                 pass
         class SerializerC(SerializerA, SerializerB):
             pass
+
+- case: model_serializer_meta_attributes
+  main: |
+    from rest_framework import serializers
+
+    reveal_type(serializers.ModelSerializer.Meta.model) # N: Revealed type is 'Type[django.db.models.base.Model]'
+    reveal_type(serializers.ModelSerializer.Meta.fields) # N: Revealed type is 'Union[typing.Sequence[builtins.str], None]'
+    reveal_type(serializers.ModelSerializer.Meta.read_only_fields) # N: Revealed type is 'Union[typing.Sequence[builtins.str], None]'
+    reveal_type(serializers.ModelSerializer.Meta.exclude) # N: Revealed type is 'Union[typing.Sequence[builtins.str], None]'
+    reveal_type(serializers.ModelSerializer.Meta.depth) # N: Revealed type is 'Union[builtins.int, None]'
+    reveal_type(serializers.ModelSerializer.Meta.extra_kwargs) # N: Revealed type is 'builtins.dict[builtins.str, builtins.dict[builtins.str, Any]]'
+
+- case: test_model_serializer_passes_check
+  main: |
+    from rest_framework import serializers
+    from django.contrib.auth.models import User
+    from typing import Type
+
+    class TestSerializer(serializers.ModelSerializer):
+        class Meta:
+          model = User
+
+    def is_meta_model(serializer: Type[serializers.ModelSerializer]) -> bool:
+        return bool(serializer.Meta.model)
+
+    reveal_type(is_meta_model(TestSerializer)) # N: Revealed type is 'builtins.bool'


### PR DESCRIPTION
`ModelSerializer` cannot be instantiated withuot the `Meta` class set
and `model` defined on it.