### PR TITLE
DynamicRoute namedtuple should not have a `mapping` attr

### DIFF
--- a/rest_framework-stubs/routers.pyi
+++ b/rest_framework-stubs/routers.pyi
@@ -19,7 +19,6 @@ class Route(NamedTuple):
 
 class DynamicRoute(NamedTuple):
     url: str
-    mapping: Dict[str, str]
     name: str
     detail: bool
     initkwargs: Dict[str, Any]

--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -36,9 +36,7 @@ class APIClient(DjangoClient):
     def head(  # type: ignore[override]
         self, path: str, data: Any = ..., secure: bool = ..., **extra: Any
     ) -> Response: ...
-    def trace(  # type: ignore[override]
-        self, path: str, secure: bool = ..., **extra: Any
-    ) -> Response: ...
+    def trace(self, path: str, secure: bool = ..., **extra: Any) -> Response: ...  # type: ignore[override]
     def options(  # type: ignore[override]
         self,
         path: str,


### PR DESCRIPTION
See definition here https://github.com/encode/django-rest-framework/blob/3.9.4/rest_framework/routers.py#L39

I am getting a `Missing positional argument "mapping" in call to "DynamicRoute"` error from mypy when trying to instantiate a DynamicRoute using these stubs currently