### PR TITLE
Specify `client` attribute of TestCase classes as APIClient

### DIFF
--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -79,14 +79,18 @@ class APIClient(APIRequestFactory, DjangoClient):
 
 class APITransactionTestCase(testcases.TransactionTestCase):
     client_class: APIClient = ...
+    client: APIClient
 
 class APITestCase(testcases.TestCase):
     client_class: APIClient = ...
+    client: APIClient
 
 class APISimpleTestCase(testcases.SimpleTestCase):
     client_class: APIClient = ...
+    client: APIClient
 
 class APILiveServerTestCase(testcases.LiveServerTestCase):
     client_class: APIClient = ...
+    client: APIClient
 
 class URLPatternsTestCase(testcases.SimpleTestCase): ...


### PR DESCRIPTION
- Fixes the following issue when you use self.client in any DRF test class
  `Incompatible types in assignment (expression has type "HttpResponse", variable has type "Response")`

Description
==========
I've recently upgraded to the latest master of both repos and ran into the above error. The issue seems to be that DRF APITestCase classes seem to be revealing type as `HttpResponse` instead of drf `Response`.
The correct`client_class` type hints exist [here](https://github.com/typeddjango/djangorestframework-stubs/blob/master/rest_framework-stubs/test.pyi#L81). But this alone doesn't seem enough to correctly type check all uses of the client. If one uses `self.client` inside a test method the client class still gets Client class instead of APIClient, because of the django-stubs [here](https://github.com/typeddjango/django-stubs/blob/master/django-stubs/test/testcases.pyi#L48).

This new error could be because of the recent changes to _django-stubs_ that have surfaced additional type hints?


Sample Test case
------------------

```test.py

from rest_framework.test import APITestCase
from rest_framework.response import Response

class MyTest(APITestCase):
    ...
    
    def test_method(self):
       # error:
       # Incompatible types in assignment (expression has type "HttpResponse", variable has type "Response")
       response: Response = self.client.post("/dummy")

```
