### PR TITLE
Fix type declaration of the urlpatterns arg of format_suffix_patterns

### DIFF
--- a/rest_framework-stubs/urlpatterns.pyi
+++ b/rest_framework-stubs/urlpatterns.pyi
@@ -9,7 +9,7 @@ def apply_suffix_patterns(
     suffix_route: Optional[str] = ...,
 ) -> List[URLPattern]: ...
 def format_suffix_patterns(
-    urlpatterns: List[URLPattern],
+    urlpatterns: List[Union[URLResolver, RoutePattern, URLPattern, Pattern]],
     suffix_required: bool = ...,
     allowed: Optional[List[Union[URLPattern, Pattern, str]]] = ...,
 ) -> List[URLPattern]: ...


### PR DESCRIPTION
The `urlpatterns` argument of `format_suffix_patterns` is incomplete, as
can be seen by the fact that `apply_suffix_patterns` is called by this former
function with argument `urlpatterns` passed straight.

Fixes #107.