### PR TITLE
Remove python3.9 constraint from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,5 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-default_language_version:
-  python: python3.9
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0


### PR DESCRIPTION
It's not required to be python 3.9 any other recent version should be enough.
At the same time if user don't have python 3.9 installed on his machine he can't run pre-commit.
