### PR TITLE
Change travis python to 3.9 (from 3.9-dev)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ sudo: required
 
 jobs:
   include:
-    - name: Run typecheck on DRF master test suite with Python 3.9-dev
-      python: 3.9-dev
+    - name: Run typecheck on DRF master test suite with Python 3.9
+      python: 3.9
       script: python ./scripts/typecheck_tests.py
 
     - name: Run typecheck on DRF master test suite with Python 3.8
@@ -22,12 +22,12 @@ jobs:
       script: python ./scripts/typecheck_tests.py
 
     - name: Lint using pre-commit
-      python: 3.9-dev
+      python: 3.9
       script:
         - pre-commit install && pre-commit run --all-files
 
-    - name: Run plugin test suite with Python 3.9-dev
-      python: 3.9-dev
+    - name: Run plugin test suite with Python 3.9
+      python: 3.9
       script: pytest
 
     - name: Run plugin test suite with Python 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 cache: pip
 dist: xenial
-sudo: required
+os: linux
 
 jobs:
   include:


### PR DESCRIPTION
At the time of merging #100 only 3.9-dev was available (and stable) in travis.

Edit: This PR didn't trigger the CI, maybe it will in some time.
Edi2: second commit triggered it. To debug it I pasted it in the linter and fixed warnings.