### PR TITLE
Fix status.HTTP_200_OK

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 wheel
-mypy==0.790
 gitpython==3.1.9
 pre-commit==2.7.1
 pytest==6.1.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 wheel
+mypy==0.790
 gitpython==3.1.9
 pre-commit==2.7.1
 pytest==6.1.1

--- a/rest_framework-stubs/status.pyi
+++ b/rest_framework-stubs/status.pyi
@@ -8,7 +8,7 @@ def is_server_error(code: int) -> bool: ...
 
 HTTP_100_CONTINUE: Literal[100]
 HTTP_101_SWITCHING_PROTOCOLS: Literal[101]
-HTTP_200_OK: Literal[202]
+HTTP_200_OK: Literal[200]
 HTTP_201_CREATED: Literal[201]
 HTTP_202_ACCEPTED: Literal[202]
 HTTP_203_NON_AUTHORITATIVE_INFORMATION: Literal[203]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,13 @@ def find_stub_files(name):
 with open("README.md") as f:
     readme = f.read()
 
-dependencies = ["mypy>=0.790", "django-stubs>=1.7.0", "typing-extensions>=3.7.2", "requests>=2.0.0", "coreapi>=2.0.0"]
+dependencies = [
+    "mypy>=0.790,<0.800",
+    "django-stubs>=1.7.0",
+    "typing-extensions>=3.7.2",
+    "requests>=2.0.0",
+    "coreapi>=2.0.0",
+]
 
 setup(
     name="djangorestframework-stubs",


### PR DESCRIPTION
`status.HTTP_200_OK` should be `Literal[200]`, not `Literal[202]`. Fixes #123.

I cannot run `pytest` because of #124, but I don't see how this could break anything.