### PR TITLE
Use BaseSchemaGenerator as a generator_class in get_schema_view

### DIFF
--- a/rest_framework-stubs/schemas/__init__.pyi
+++ b/rest_framework-stubs/schemas/__init__.pyi
@@ -5,9 +5,11 @@ from rest_framework.settings import api_settings as api_settings
 
 from . import coreapi as coreapi
 from . import openapi as openapi
+
 from .coreapi import AutoSchema as AutoSchema
 from .coreapi import ManualSchema as ManualSchema
 from .coreapi import SchemaGenerator as SchemaGenerator
+from .generators import BaseSchemaGenerator
 from .inspectors import DefaultSchema as DefaultSchema
 
 def get_schema_view(
@@ -18,7 +20,7 @@ def get_schema_view(
     renderer_classes: Optional[Sequence[Type[BaseRenderer]]] = ...,
     public: bool = ...,
     patterns: Optional[Sequence[Any]] = ...,
-    generator_class: Type[Union[openapi.SchemaGenerator, coreapi.SchemaGenerator]] = ...,
+    generator_class: Type[BaseSchemaGenerator] = ...,
     authentication_classes: Sequence[str] = ...,
     permission_classes: Sequence[str] = ...,
     version: Optional[str] = ...,

--- a/rest_framework-stubs/schemas/__init__.pyi
+++ b/rest_framework-stubs/schemas/__init__.pyi
@@ -18,7 +18,7 @@ def get_schema_view(
     renderer_classes: Optional[Sequence[Type[BaseRenderer]]] = ...,
     public: bool = ...,
     patterns: Optional[Sequence[Any]] = ...,
-    generator_class: Type[SchemaGenerator] = ...,
+    generator_class: Type[Union[openapi.SchemaGenerator, coreapi.SchemaGenerator]] = ...,
     authentication_classes: Sequence[str] = ...,
     permission_classes: Sequence[str] = ...,
     version: Optional[str] = ...,


### PR DESCRIPTION
```python
# main.py
from rest_framework.schemas import get_schema_view
from rest_framework.schemas.coreapi import SchemaGenerator


class SchemaGenerator2(SchemaGenerator):
    pass

get_schema_view(
    generator_class=SchemaGenerator2
)
```

```bash
mypy  main.py

 Argument "generator_class" to "get_schema_view" has incompatible type "Type[SchemaGenerator2]"; expected "Type[SchemaGenerator]"
```