### PR TITLE
Add Mypy 0.900 compatibility

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,5 @@ pre-commit==2.7.1
 pytest==6.1.1
 pytest-mypy-plugins==1.6.1
 djangorestframework==3.12.1
+types-pytz==0.1.2
 -e .

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -104,7 +104,7 @@ IGNORED_ERRORS = {
         'Argument "params" to "ValidationError" has incompatible type "Tuple[str]"',
         '"MultipleChoiceField[Model]" has no attribute "partial"',
         'Argument 1 to "to_internal_value" of "Field" has incompatible type "Dict[str, str]"; expected "List[Any]"',
-        "Module 'rest_framework.fields' has no attribute 'DjangoImageField'",
+        'Module "rest_framework.fields" has no attribute "DjangoImageField"; maybe "ImageField"?',
     ],
     "test_filters.py": [
         'Module has no attribute "coreapi"',
@@ -172,7 +172,7 @@ IGNORED_ERRORS = {
         "base class",
         '(expression has type "IntegerField", base class "Base" defined the type as "CharField")',
         '"CharField" has incompatible type "Collection[Any]"',
-        "Name 'foo' is not defined",
+        'Name "foo" is not defined',
         'Argument "data" has incompatible type "None"',
     ],
     "test_serializer_bulk_update.py": [
@@ -182,7 +182,7 @@ IGNORED_ERRORS = {
     ],
     "test_serializer_lists.py": [
         'The type "Type[ListSerializer]" is not generic and not indexable',
-        "Name 'foo' is not defined",
+        'Name "foo" is not defined',
     ],
     "test_serializer_nested.py": [
         '(expression has type "NestedSerializer", base class "Field" defined the type as "bool")',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ dependencies = [
     "typing-extensions>=3.7.2",
     "requests>=2.0.0",
     "coreapi>=2.0.0",
+    "types-requests>=0.1.12",
+    "types-PyYAML>=5.4.3",
+    "types-Markdown>=0.1.5",
 ]
 
 setup(

--- a/tests/typecheck/test_api_client.yml
+++ b/tests/typecheck/test_api_client.yml
@@ -6,4 +6,4 @@
 
             def test_my_code(self):
                 client = test.APIClient()
-                reveal_type(client.post('http://google.com'))  # N: Revealed type is 'rest_framework.response.Response'
+                reveal_type(client.post('http://google.com'))  # N: Revealed type is "rest_framework.response.Response"

--- a/tests/typecheck/test_compat.yml
+++ b/tests/typecheck/test_compat.yml
@@ -2,5 +2,5 @@
   main: |
     from rest_framework.compat import postgres_fields
 
-    reveal_type(postgres_fields)  # N: Revealed type is '_importlib_modulespec.ModuleType'
-    reveal_type(postgres_fields.hstore.HStoreField())  # N: Revealed type is 'django.contrib.postgres.fields.hstore.HStoreField'
+    reveal_type(postgres_fields)  # N: Revealed type is "types.ModuleType"
+    reveal_type(postgres_fields.hstore.HStoreField())  # N: Revealed type is "django.contrib.postgres.fields.hstore.HStoreField"

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -3,7 +3,7 @@
         from rest_framework.decorators import api_view
         @api_view()
         def view_func1(request): ...
-        reveal_type(view_func1)  # N: Revealed type is 'rest_framework.views.AsView[def (request: Any) -> Any]'
+        reveal_type(view_func1)  # N: Revealed type is "rest_framework.views.AsView[def (request: Any) -> Any]"
 -   case: api_view_fancy
     main: |
         from rest_framework.decorators import api_view
@@ -11,7 +11,7 @@
         from rest_framework.response import Response
         @api_view(['GET', 'POST'])
         def view_func2(request: Request, arg: str) -> Response: ...
-        reveal_type(view_func2)  # N: Revealed type is 'rest_framework.views.AsView[def (request: rest_framework.request.Request, arg: builtins.str) -> rest_framework.response.Response]'
+        reveal_type(view_func2)  # N: Revealed type is "rest_framework.views.AsView[def (request: rest_framework.request.Request, arg: builtins.str) -> rest_framework.response.Response]"
 
         view_func2(None, 10)  # E: Argument 1 to "view_func2" has incompatible type "None"; expected "Request"  # E: Argument 2 to "view_func2" has incompatible type "int"; expected "str"
 -   case: api_view_bare_is_error

--- a/tests/typecheck/test_serializers.yml
+++ b/tests/typecheck/test_serializers.yml
@@ -14,12 +14,12 @@
   main: |
     from rest_framework import serializers
 
-    reveal_type(serializers.ModelSerializer.Meta.model) # N: Revealed type is 'Type[_MT?]'
-    reveal_type(serializers.ModelSerializer.Meta.fields) # N: Revealed type is 'typing.Sequence[builtins.str]'
-    reveal_type(serializers.ModelSerializer.Meta.read_only_fields) # N: Revealed type is 'Union[typing.Sequence[builtins.str], None]'
-    reveal_type(serializers.ModelSerializer.Meta.exclude) # N: Revealed type is 'Union[typing.Sequence[builtins.str], None]'
-    reveal_type(serializers.ModelSerializer.Meta.depth) # N: Revealed type is 'Union[builtins.int, None]'
-    reveal_type(serializers.ModelSerializer.Meta.extra_kwargs) # N: Revealed type is 'builtins.dict[builtins.str, builtins.dict[builtins.str, Any]]'
+    reveal_type(serializers.ModelSerializer.Meta.model) # N: Revealed type is "Type[_MT?]"
+    reveal_type(serializers.ModelSerializer.Meta.fields) # N: Revealed type is "typing.Sequence[builtins.str]"
+    reveal_type(serializers.ModelSerializer.Meta.read_only_fields) # N: Revealed type is "Union[typing.Sequence[builtins.str], None]"
+    reveal_type(serializers.ModelSerializer.Meta.exclude) # N: Revealed type is "Union[typing.Sequence[builtins.str], None]"
+    reveal_type(serializers.ModelSerializer.Meta.depth) # N: Revealed type is "Union[builtins.int, None]"
+    reveal_type(serializers.ModelSerializer.Meta.extra_kwargs) # N: Revealed type is "builtins.dict[builtins.str, builtins.dict[builtins.str, Any]]"
 
 - case: test_model_serializer_passes_check
   main: |
@@ -34,7 +34,7 @@
     def is_meta_model(serializer: Type[serializers.ModelSerializer]) -> bool:
         return bool(serializer.Meta.model)
 
-    reveal_type(is_meta_model(TestSerializer)) # N: Revealed type is 'builtins.bool'
+    reveal_type(is_meta_model(TestSerializer)) # N: Revealed type is "builtins.bool"
 
 - case: test_model_serializer_with_customized_serializer_field_mapping
   main: |

--- a/tests/typecheck/test_views.yml
+++ b/tests/typecheck/test_views.yml
@@ -4,7 +4,7 @@
 
     class MyListView(generics.ListAPIView):
         def filter_queryset(self, queryset):
-            reveal_type(self.request)  # N: Revealed type is 'rest_framework.request.Request'
+            reveal_type(self.request)  # N: Revealed type is "rest_framework.request.Request"
             return queryset
 
 - case: test_destroy_api_view
@@ -28,5 +28,5 @@
     request: HttpRequest
     view: APIView
     api_request = view.initialize_request(request)
-    reveal_type(api_request)  # N: Revealed type is 'rest_framework.request.Request'
+    reveal_type(api_request)  # N: Revealed type is "rest_framework.request.Request"
 


### PR DESCRIPTION
- Adds a dependency on a couple stub packages that Mypy suggested since it doesn't bundle typeshed anymore in 0.900 (added `types-pytz` as a dev-only dependency because `pytz` is never imported in the stubs, but it's used in DRF's test suite)
- Fixes the test output to match Mypy 0.900