### PR TITLE
Add permissions.OperandHolder to decorators.permission_classes signature

### DIFF
--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -3,7 +3,7 @@ from typing import Any, Callable, List, Mapping, Optional, Sequence, Type, Union
 from django.http.response import HttpResponseBase
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.parsers import BaseParser
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import BasePermission, OperandHolder
 from rest_framework.renderers import BaseRenderer
 from rest_framework.schemas.inspectors import ViewInspector
 from rest_framework.throttling import BaseThrottle
@@ -76,7 +76,7 @@ def throttle_classes(
     throttle_classes: Sequence[Union[BaseThrottle, Type[BaseThrottle]]]
 ) -> Callable[[_View], _View]: ...
 def permission_classes(
-    permission_classes: Sequence[Union[BasePermission, Type[BasePermission]]]
+    permission_classes: Sequence[Union[BasePermission, Type[BasePermission], OperandHolder]]
 ) -> Callable[[_View], _View]: ...
 def schema(view_inspector: Optional[Union[ViewInspector, Type[ViewInspector]]]) -> Callable[[_View], _View]: ...
 def action(

--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -3,7 +3,7 @@ from typing import Any, Callable, List, Mapping, Optional, Sequence, Type, Union
 from django.http.response import HttpResponseBase
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.parsers import BaseParser
-from rest_framework.permissions import BasePermission, OperandHolder
+from rest_framework.permissions import _PermissionClass
 from rest_framework.renderers import BaseRenderer
 from rest_framework.schemas.inspectors import ViewInspector
 from rest_framework.throttling import BaseThrottle
@@ -75,9 +75,7 @@ def authentication_classes(
 def throttle_classes(
     throttle_classes: Sequence[Union[BaseThrottle, Type[BaseThrottle]]]
 ) -> Callable[[_View], _View]: ...
-def permission_classes(
-    permission_classes: Sequence[Union[BasePermission, Type[BasePermission], OperandHolder]]
-) -> Callable[[_View], _View]: ...
+def permission_classes(permission_classes: Sequence[_PermissionClass]) -> Callable[[_View], _View]: ...
 def schema(view_inspector: Optional[Union[ViewInspector, Type[ViewInspector]]]) -> Callable[[_View], _View]: ...
 def action(
     methods: Optional[_MIXED_CASE_HTTP_VERBS] = ...,

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -24,3 +24,8 @@
         from rest_framework.decorators import api_view
         @api_view()  # E: Value of type variable "_View" of function cannot be "Callable[[Any], List[Any]]"
         def view_func2(request) -> list: ...
+
+-   case: permission_classes
+    main: |
+        from rest_framework.decorators import permission_classes
+        reveal_type(permission_classes) # N: Revealed type is "def (permission_classes: typing.Sequence[Union[Type[rest_framework.permissions.BasePermission], rest_framework.permissions.OperandHolder, rest_framework.permissions.SingleOperandHolder]]) -> def [_View <: def (*Any, **Any) -> django.http.response.HttpResponseBase] (_View`-1) -> _View`-1"

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -29,3 +29,15 @@
     main: |
         from rest_framework.decorators import permission_classes
         reveal_type(permission_classes) # N: Revealed type is "def (permission_classes: typing.Sequence[Union[Type[rest_framework.permissions.BasePermission], rest_framework.permissions.OperandHolder, rest_framework.permissions.SingleOperandHolder]]) -> def [_View <: def (*Any, **Any) -> django.http.response.HttpResponseBase] (_View`-1) -> _View`-1"
+
+-   case: permission_classes_with_operators
+    main: |
+        from rest_framework.permissions import BasePermission, IsAuthenticated
+        from rest_framework.decorators import permission_classes
+
+        class Permission(BasePermission):
+            pass
+
+        permission_classes([IsAuthenticated & Permission])
+        permission_classes([IsAuthenticated | Permission])
+        permission_classes([~Permission])


### PR DESCRIPTION
Hello, this will allow `permission_classes` to accept types like `BasePermission & BasePermission`.
i am not sure if i should import `_PermissionsClasses` as defined in the permissions stub and remove the preceding underscore, feedback is appreciated.