### PR TITLE
Allow fields to be None

### DIFF
--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -221,7 +221,7 @@ class ModelSerializer(Serializer, BaseSerializer[_MT]):
     instance: Optional[Union[_MT, Sequence[_MT]]]  # type: ignore[override]
     class Meta:
         model: Type[_MT] # type: ignore
-        fields: Union[Sequence[str], Literal["__all__"]]
+        fields: Optional[Union[Sequence[str], Literal["__all__"]]]
         read_only_fields: Optional[Sequence[str]]
         exclude: Optional[Sequence[str]]
         depth: Optional[int]


### PR DESCRIPTION
`fields` could be `None` if `exclude` is provided. Though I guess no way to represent in types that you need one or the other populated.