### PR TITLE
Make method_name optional in SerializerMethodField

### DIFF
--- a/rest_framework-stubs/fields.pyi
+++ b/rest_framework-stubs/fields.pyi
@@ -689,7 +689,7 @@ class SerializerMethodField(Field):
     method_name: str = ...
     def __init__(
         self,
-        method_name: str = ...,
+        method_name: Optional[str] = ...,
         *,
         read_only: bool = ...,
         write_only: bool = ...,


### PR DESCRIPTION
https://www.django-rest-framework.org/api-guide/fields/#serializermethodfield

You can leave the method_name parameter empty, to get a default value.

For a long time, drf even gave an error when you provided a parameter that matched `get_` your field name:
https://github.com/encode/django-rest-framework/issues/2420