### PR TITLE
Test suite fixes

### DIFF
--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional, Union
 
 import coreapi
 import requests
+import urllib3
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
@@ -17,7 +18,7 @@ def force_authenticate(
     request: HttpRequest, user: Optional[Union[AnonymousUser, AbstractBaseUser]] = ..., token: Optional[Token] = ...
 ) -> None: ...
 
-class HeaderDict(requests.packages.urllib3._collections.HTTPHeaderDict):
+class HeaderDict(urllib3._collections.HTTPHeaderDict):
     def get_all(self, key: Any, default: Any): ...
 
 class MockOriginalResponse:

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ dependencies = [
     "requests>=2.0.0",
     "coreapi>=2.0.0",
     "types-requests>=0.1.12",
+    "types-urllib3<1.27",  # keep in sync with requests's setup.py
     "types-PyYAML>=5.4.3",
     "types-Markdown>=0.1.5",
 ]

--- a/tests/typecheck/test_serializers.yml
+++ b/tests/typecheck/test_serializers.yml
@@ -15,7 +15,7 @@
     from rest_framework import serializers
 
     reveal_type(serializers.ModelSerializer.Meta.model) # N: Revealed type is "Type[_MT?]"
-    reveal_type(serializers.ModelSerializer.Meta.fields) # N: Revealed type is "typing.Sequence[builtins.str]"
+    reveal_type(serializers.ModelSerializer.Meta.fields) # N: Revealed type is "Union[typing.Sequence[builtins.str], Literal['__all__']]"
     reveal_type(serializers.ModelSerializer.Meta.read_only_fields) # N: Revealed type is "Union[typing.Sequence[builtins.str], None]"
     reveal_type(serializers.ModelSerializer.Meta.exclude) # N: Revealed type is "Union[typing.Sequence[builtins.str], None]"
     reveal_type(serializers.ModelSerializer.Meta.depth) # N: Revealed type is "Union[builtins.int, None]"


### PR DESCRIPTION
I spent some time trying to get the tests to run.

Apart from pointing `django-stubs` at https://github.com/typeddjango/django-stubs/pull/786, I had to make two more changes

1. `types-requests` no longer vendors `urllib3` stubs.

    I just copied what `types-requests` have done themselves here - depend on `types-urllib3` and use them directly in `test.pyi`.

2. Fix a test expectation.

    This was failing:

https://github.com/typeddjango/djangorestframework-stubs/blob/466b1f5f0dd2f80eea6fcebb13114118489686a7/tests/typecheck/test_serializers.yml#L18

for

https://github.com/typeddjango/djangorestframework-stubs/blob/466b1f5f0dd2f80eea6fcebb13114118489686a7/rest_framework-stubs/serializers.pyi#L224

The tests still won't pass until a new `django-stubs` comes in, but hopefully it helps getting these out of the way.
