### PR TITLE
Covariant type parameters for format_suffix_patterns.

### DIFF
--- a/rest_framework-stubs/urlpatterns.pyi
+++ b/rest_framework-stubs/urlpatterns.pyi
@@ -1,15 +1,15 @@
-from typing import List, Optional, Pattern, Union
+from typing import Iterable, List, Optional, Pattern, Sequence, Union
 
 from django.urls.resolvers import RoutePattern, URLPattern, URLResolver
 
 def apply_suffix_patterns(
-    urlpatterns: List[Union[URLResolver, RoutePattern, URLPattern, Pattern]],
+    urlpatterns: Iterable[Union[URLResolver, RoutePattern, URLPattern, Pattern]],
     suffix_pattern: Union[str, Pattern],
     suffix_required: bool,
     suffix_route: Optional[str] = ...,
 ) -> List[URLPattern]: ...
 def format_suffix_patterns(
-    urlpatterns: List[Union[URLResolver, RoutePattern, URLPattern, Pattern]],
+    urlpatterns: Iterable[Union[URLResolver, RoutePattern, URLPattern, Pattern]],
     suffix_required: bool = ...,
-    allowed: Optional[List[Union[URLPattern, Pattern, str]]] = ...,
+    allowed: Optional[Sequence[Union[URLPattern, Pattern, str]]] = ...,
 ) -> List[URLPattern]: ...


### PR DESCRIPTION
Define `urlpatterns` as `Iterable`, they are only iterated over inside
`apply_suffix_patterns`.

Define `allowed` as `Optional[Sequence[...]]` instead as it is documented as tuple/list
and needs to support `__len__` and `__getitem__`.

Closes #184 