### PR TITLE
Fix the APIException detail attribute type

### DIFF
--- a/rest_framework-stubs/exceptions.pyi
+++ b/rest_framework-stubs/exceptions.pyi
@@ -12,7 +12,7 @@ class ErrorDetail(str):
     code: Optional[str] = None
     def __new__(cls, string: str, code: Optional[str] = ...): ...
 
-_Detail = Union[str, List[Any], Dict[str, Any]]
+_Detail = Union[ErrorDetail, List[ErrorDetail], Dict[str, ErrorDetail]]
 
 class APIException(Exception):
     status_code: int = ...


### PR DESCRIPTION
DRF does not use raw strings but the ErrorDetail which is a subclass of str

See: https://github.com/encode/django-rest-framework/blob/master/rest_framework/exceptions.py#L18
