### PR TITLE
[Fix] Serializer fields decorator

### DIFF
--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -23,6 +23,7 @@ from django.db.models import DurationField as ModelDurationField
 from django.db.models import Manager, Model, QuerySet
 from django.db.models.fields import Field as DjangoModelField
 from django.utils.translation import ugettext_lazy as _
+from django.utils.functional import cached_property
 from typing_extensions import Literal
 
 from rest_framework.exceptions import APIException as APIException
@@ -148,7 +149,7 @@ class Serializer(
     _declared_fields: Dict[str, Field]
     default_error_messages: Dict[str, Any] = ...
     def get_initial(self) -> Any: ...
-    @property
+    @cached_property
     def fields(self) -> BindingDict: ...
     def get_fields(self) -> Dict[str, Field]: ...
     def validate(self, attrs: Any) -> Any: ...

--- a/tests/typecheck/test_serializers.yml
+++ b/tests/typecheck/test_serializers.yml
@@ -60,3 +60,18 @@
 
         class Meta:
             model = User
+
+- case: test_model_serializer_with_overriden_fields_property
+  main: |
+    from rest_framework import serializers
+    from rest_framework.utils.serializer_helpers import BindingDict
+    from django.contrib.auth.models import User
+    from django.utils.functional import cached_property
+
+    class TestSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = User
+
+        @cached_property
+        def fields(self) -> BindingDict:
+            return super().fields


### PR DESCRIPTION
Hey there,

Currently, the `Serializer.fields` property stub is decorated with `property`, but as you can see [here](https://github.com/encode/django-rest-framework/blob/3.13.1/rest_framework/serializers.py#L347), a `cached_property` is actually used.

When overriding the property, to make sure it type checks correctly, one would have to use `property`. This PR fixes that.
Added one test that confirms it.

Let me know if there's anything else, I can do.