### PR TITLE
Update to django-stubs latest

### DIFF
--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -1,7 +1,8 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Type, Union
 
 import coreapi
 import requests
+import urllib3
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
@@ -12,7 +13,6 @@ from django.test.client import RequestFactory as DjangoRequestFactory
 from rest_framework.authtoken.models import Token
 from rest_framework.request import Request
 from rest_framework.response import Response
-import urllib3
 
 def force_authenticate(
     request: HttpRequest, user: Optional[Union[AnonymousUser, AbstractBaseUser]] = ..., token: Optional[Token] = ...
@@ -80,15 +80,15 @@ class APIClient(APIRequestFactory, DjangoClient):
     def logout(self) -> None: ...
 
 class APITransactionTestCase(testcases.TransactionTestCase):
-    client_class: APIClient = ...
+    client_class: Type[APIClient] = ...
 
 class APITestCase(testcases.TestCase):
-    client_class: APIClient = ...
+    client_class: Type[APIClient] = ...
 
 class APISimpleTestCase(testcases.SimpleTestCase):
-    client_class: APIClient = ...
+    client_class: Type[APIClient] = ...
 
 class APILiveServerTestCase(testcases.LiveServerTestCase):
-    client_class: APIClient = ...
+    client_class: Type[APIClient] = ...
 
 class URLPatternsTestCase(testcases.SimpleTestCase): ...

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -44,20 +44,21 @@ IGNORED_ERRORS = {
         "Need type annotation for",
         "Cannot assign to a method",
         "Cannot determine type of",
-        '"HttpResponse" has no attribute "data"',
         'has no attribute "initkwargs"',
         'has no attribute "mapping"',
         'Response" has no attribute "view"',
         "Cannot infer type",
         ' has no attribute "_context',
         '(expression has type "None", variable has type "ForeignKeyTarget")',
+        '"_MonkeyPatchedWSGIResponse" has no attribute "content"',
+        '"_MonkeyPatchedWSGIResponse" has no attribute "data"',
     ],
     "authentication": [
         'Argument 1 to "post" of "APIClient" has incompatible type "None"; expected "str',
         ' base class "BaseTokenAuthTests" defined the type as "None"',
         '"None" has no attribute "objects"',
         '"BaseTokenAuthTests" has no attribute "assertNumQueries"',
-        'Module "django.middleware.csrf" has no attribute "_mask_cipher_secret"; maybe "_salt_cipher_secret"?',
+        'Module "django.middleware.csrf" has no attribute "_mask_cipher_secret"',
         "All conditional function variants must have identical signatures",
     ],
     "schemas": [
@@ -113,6 +114,10 @@ IGNORED_ERRORS = {
         'Argument 1 to "to_internal_value" of "Field" has incompatible type "Dict[str, str]"; expected "List[Any]"',
         'Module "rest_framework.fields" has no attribute "DjangoImageField"; maybe "ImageField"?',
         'Argument 1 to "ListField" has incompatible type "CharField"; expected "bool"',
+        "Possible overload variants:",
+        "def __init__(self, *, mutable: Literal[True], query_string: Union[str, bytes, None] = ..., encoding: Optional[str] = ...) -> QueryDict",  # noqa: E501
+        "def __init__(self, query_string: Union[str, bytes, None] = ..., mutable: bool = ..., encoding: Optional[str] = ...) -> _ImmutableQueryDict",  # noqa: E501
+        "def __init__(self, query_string: Union[str, bytes, None], mutable: Literal[True], encoding: Optional[str] = ...) -> QueryDict",  # noqa: E501
     ],
     "test_filters.py": [
         'Module has no attribute "coreapi"',
@@ -236,6 +241,8 @@ IGNORED_ERRORS = {
         'Argument "queryset" to "BaseUniqueForValidator" has incompatible type "object";'
         ' expected "_QuerySet[Any, Any]"',
         'to "filter_queryset" of "BaseUniqueForValidator" has incompatible type "None"',
+        'Item "ForeignObjectRel" of "Union[Field[Any, Any], ForeignObjectRel, GenericForeignKey]" has no attribute "validators"',  # noqa: E501
+        'Item "GenericForeignKey" of "Union[Field[Any, Any], ForeignObjectRel, GenericForeignKey]" has no attribute "validators"',  # noqa: E501
     ],
     "test_versioning.py": [
         '(expression has type "Type[FakeResolverMatch]", variable has type "ResolverMatch")',

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -247,6 +247,7 @@ IGNORED_ERRORS = {
     "test_versioning.py": [
         '(expression has type "Type[FakeResolverMatch]", variable has type "ResolverMatch")',
         "rest_framework.decorators",
+        'Argument 1 to "include" has incompatible type "Tuple[List[object], str]"',
     ],
     "test_viewsets.py": [
         '(expression has type "None", variable has type "HttpRequest")',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ with open("README.md") as f:
 
 dependencies = [
     "mypy>=0.930,<0.950",
-    "django-stubs>=1.10.1",
+    # FIXME revert when django-stubs is released
+    "django-stubs @ git+https://github.com/typeddjango/django-stubs@master#egg=django-stubs",
     "typing-extensions>=3.7.2",
     "requests>=2.0.0",
     "coreapi>=2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ with open("README.md") as f:
 
 dependencies = [
     "mypy>=0.930,<0.950",
-    # FIXME revert when django-stubs is released
-    "django-stubs @ git+https://github.com/typeddjango/django-stubs@master#egg=django-stubs",
+    "django-stubs>=1.11.0",
     "typing-extensions>=3.7.2",
     "requests>=2.0.0",
     "coreapi>=2.0.0",

--- a/tests/typecheck/test_fields.yml
+++ b/tests/typecheck/test_fields.yml
@@ -129,12 +129,12 @@
         FileField(allow_null=True, default=None)
         FileField(allow_null=True, default=file_callback)
         FileField(allow_null=True, default=file_callback())
-        FileField(allow_null=True, default=123) # E: Argument "default" to "FileField" has incompatible type "int"; expected "Union[File, Callable[[], File], None, _Empty]"
+        FileField(allow_null=True, default=123) # E: Argument "default" to "FileField" has incompatible type "int"; expected "Union[File[Any], Callable[[], File[Any]], None, _Empty]"
 
         ImageField(allow_null=True, default=None)
         ImageField(default=file_callback)
         ImageField(default=file_callback())
-        ImageField(default='a') # E: Argument "default" to "ImageField" has incompatible type "str"; expected "Union[File, Callable[[], File], None, _Empty]"
+        ImageField(default='a') # E: Argument "default" to "ImageField" has incompatible type "str"; expected "Union[File[Any], Callable[[], File[Any]], None, _Empty]"
 
 -   case: DictField_default
     main: |


### PR DESCRIPTION
# I have made things!

This PR applies changes to make `djangorestframework-stubs` work with the latest changes in `django-stubs`.

## Related issues

Depends on:
* https://github.com/typeddjango/django-stubs/pull/941
* https://github.com/typeddjango/django-stubs/pull/942
* https://github.com/typeddjango/django-stubs/pull/943
* https://github.com/typeddjango/django-stubs/pull/945

Once these are merged and `django-stubs` is released, then this can be merged as well.
