### PR TITLE
Update to mypy 0.950

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=0.930,<0.950",
+    "mypy>=0.930,<0.960",
     "django-stubs>=1.11.0",
     "typing-extensions>=3.7.2",
     "requests>=2.0.0",

--- a/tests/typecheck/test_pagination.yml
+++ b/tests/typecheck/test_pagination.yml
@@ -9,4 +9,4 @@
     request: Request
     queryset: QuerySet[User]
     page = paginator.paginate_queryset(queryset, request)
-    reveal_type(page)  # N: Revealed type is "Union[builtins.list[django.contrib.auth.models.User*], None]"
+    reveal_type(page)  # N: Revealed type is "Union[builtins.list[django.contrib.auth.models.User], None]"

--- a/tests/typecheck/test_serializers.yml
+++ b/tests/typecheck/test_serializers.yml
@@ -15,7 +15,7 @@
     from rest_framework import serializers
 
     reveal_type(serializers.ModelSerializer.Meta.model) # N: Revealed type is "Type[_MT?]"
-    reveal_type(serializers.ModelSerializer.Meta.fields) # N: Revealed type is "Union[typing.Sequence[builtins.str], Literal['__all__']]"
+    reveal_type(serializers.ModelSerializer.Meta.fields) # N: Revealed type is "typing.Sequence[builtins.str]"
     reveal_type(serializers.ModelSerializer.Meta.read_only_fields) # N: Revealed type is "Union[typing.Sequence[builtins.str], None]"
     reveal_type(serializers.ModelSerializer.Meta.exclude) # N: Revealed type is "Union[typing.Sequence[builtins.str], None]"
     reveal_type(serializers.ModelSerializer.Meta.depth) # N: Revealed type is "Union[builtins.int, None]"


### PR DESCRIPTION
# I have made things!

Requires `django-stubs` to be released with mypy 0.950 support (https://github.com/typeddjango/django-stubs/pull/939)

I think it also depends on #213, mypy 0.950 doesn't like django-stubs 1.10.1.

## Related issues

* Depends on: #213
* Depends on: https://github.com/typeddjango/django-stubs/pull/939
