### PR TITLE
Accurately hint @api_view decorator with ParamSpec (PEP 612)

### DIFF
--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -1,16 +1,20 @@
-from typing import Any, Callable, List, Mapping, Optional, Sequence, Type, Union, Protocol, TypeVar
+from typing import Any, Callable, List, Mapping, Optional, Protocol, Sequence, Type, TypeVar, Union
 
+from django.http import HttpRequest
 from django.http.response import HttpResponseBase
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.parsers import BaseParser
 from rest_framework.permissions import _PermissionClass
 from rest_framework.renderers import BaseRenderer
+from rest_framework.request import Request
 from rest_framework.schemas.inspectors import ViewInspector
 from rest_framework.throttling import BaseThrottle
 from rest_framework.views import APIView, AsView  # noqa: F401
-from typing_extensions import Literal
+from typing_extensions import Concatenate, Literal, ParamSpec
 
 _View = TypeVar("_View", bound=Callable[..., HttpResponseBase])
+_P = ParamSpec("_P")
+_RESP = TypeVar("_RESP", bound=HttpResponseBase)
 
 class MethodMapper(dict):
     def __init__(self, action: _View, methods: Sequence[str]) -> None: ...
@@ -64,7 +68,9 @@ class ViewSetAction(Protocol[_View]):
     mapping: MethodMapper
     __call__: _View
 
-def api_view(http_method_names: Optional[Sequence[str]] = ...) -> Callable[[_View], AsView[_View]]: ...
+def api_view(
+    http_method_names: Optional[Sequence[str]] = ...,
+) -> Callable[[Callable[Concatenate[Request, _P], _RESP]], AsView[Callable[Concatenate[HttpRequest, _P], _RESP]]]: ...
 def renderer_classes(
     renderer_classes: Sequence[Union[BaseRenderer, Type[BaseRenderer]]]
 ) -> Callable[[_View], _View]: ...

--- a/rest_framework-stubs/views.pyi
+++ b/rest_framework-stubs/views.pyi
@@ -6,12 +6,12 @@ from typing import (
     Mapping,
     NoReturn,
     Optional,
+    Protocol,
     Sequence,
     Tuple,
     Type,
-    Union,
-    Protocol,
     TypeVar,
+    Union,
 )
 
 from django.http import HttpRequest
@@ -38,7 +38,7 @@ def exception_handler(exc: Exception, context) -> Optional[Response]: ...
 _View = TypeVar("_View", bound=Callable[..., HttpResponseBase])
 
 class AsView(Protocol[_View]):
-    self: APIView
+    cls: Type[APIView]
     view_class: Type[APIView]
     view_initkwargs: Mapping[str, Any]
     csrf_exempt: bool

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -73,7 +73,7 @@ IGNORED_ERRORS = {
         'List item 0 has incompatible type "Type[',
         'error: Module has no attribute "coreapi"',
         'Value of type "Optional[str]" is not indexable',
-        'Incompatible types in assignment (expression has type "AsView[GenericView]", variable has type "AsView[Callable[[Any], Any]]")',  # noqa: E501
+        'Incompatible types in assignment (expression has type "AsView[GenericView]", variable has type "AsView[Callable[[HttpRequest], Any]]")',  # noqa: E501
         'Argument "patterns" to "SchemaGenerator" has incompatible type "List[object]"',
         'Argument 1 to "field_to_schema" has incompatible type "object"; expected "Field[Any, Any, Any, Any]"',
     ],

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=0.930,<0.960",
+    "mypy>=0.950,<0.960",
     "django-stubs>=1.11.0",
-    "typing-extensions>=3.7.2",
+    "typing-extensions>=3.10.0",
     "requests>=2.0.0",
     "coreapi>=2.0.0",
     "types-requests>=0.1.12",

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -3,7 +3,7 @@
         from rest_framework.decorators import api_view
         @api_view()
         def view_func1(request): ...
-        reveal_type(view_func1)  # N: Revealed type is "rest_framework.views.AsView[def (request: Any) -> Any]"
+        reveal_type(view_func1)  # N: Revealed type is "rest_framework.views.AsView[def (django.http.request.HttpRequest) -> Any]"
 -   case: api_view_fancy
     main: |
         from rest_framework.decorators import api_view
@@ -11,9 +11,9 @@
         from rest_framework.response import Response
         @api_view(['GET', 'POST'])
         def view_func2(request: Request, arg: str) -> Response: ...
-        reveal_type(view_func2)  # N: Revealed type is "rest_framework.views.AsView[def (request: rest_framework.request.Request, arg: builtins.str) -> rest_framework.response.Response]"
+        reveal_type(view_func2)  # N: Revealed type is "rest_framework.views.AsView[def (django.http.request.HttpRequest, arg: builtins.str) -> rest_framework.response.Response]"
 
-        view_func2(None, 10)  # E: Argument 1 to "view_func2" has incompatible type "None"; expected "Request"  # E: Argument 2 to "view_func2" has incompatible type "int"; expected "str"
+        view_func2(None, 10)  # E: Argument 1 has incompatible type "None"; expected "HttpRequest"  # E: Argument 2 has incompatible type "int"; expected "str"
 -   case: api_view_bare_is_error
     main: |
         from rest_framework.decorators import api_view
@@ -22,7 +22,7 @@
 -   case: api_view_incorrect_return
     main: |
         from rest_framework.decorators import api_view
-        @api_view()  # E: Value of type variable "_View" of function cannot be "Callable[[Any], List[Any]]"
+        @api_view()  # E: Value of type variable "_RESP" of function cannot be "List[Any]"
         def view_func2(request) -> list: ...
 
 -   case: permission_classes


### PR DESCRIPTION
Callers of the decorated function are expected to pass `HttpRequest` for the request argument, but internally the function gets DRF's `Request` instance.

Using ParamSpec and Concatenate from PEP 612, it's now possible to accurately type hint this.

This requires mypy 0.950 and typing-extensions 3.10.0.
