### PR TITLE
Make coreapi & markdown requirements optional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest==7.1.2
 pytest-mypy-plugins==1.9.3
 djangorestframework==3.13.1
 types-pytz==2022.1.1
--e .[compatible-mypy]
+-e .[compatible-mypy,coreapi,markdown]

--- a/rest_framework-stubs/compat.pyi
+++ b/rest_framework-stubs/compat.pyi
@@ -1,6 +1,5 @@
 from typing import Any, Optional, Tuple, Union
 
-import coreapi  # noqa: F401
 import requests  # noqa: F401
 from django.db.models import QuerySet
 
@@ -8,6 +7,10 @@ try:
     from django.contrib.postgres import fields as postgres_fields
 except ImportError:
     postgres_fields = None  # type: ignore
+try:
+    import coreapi
+except ImportError:
+    coreapi = None  # type: ignore
 try:
     import uritemplate
 except ImportError:
@@ -29,7 +32,7 @@ try:
 except ImportError:
     pygments = None  # type: ignore
 try:
-    import markdown
+    import markdown  # type: ignore
     def apply_markdown(text: str): ...
 
 except ImportError:
@@ -37,7 +40,7 @@ except ImportError:
     markdown = None  # type: ignore
 
 if markdown is not None and pygments is not None:
-    from markdown.preprocessors import Preprocessor
+    from markdown.preprocessors import Preprocessor  # type: ignore
 
     class CodeBlockPreprocessor(Preprocessor):
         pattern: Any = ...

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ dependencies = [
 extras_require = {
     "compatible-mypy": ["mypy>=0.950,<0.970"],
     "coreapi": ["coreapi>=2.0.0"],
-    "markdown": ["types-Markdown>=0.1.5"]
+    "markdown": ["types-Markdown>=0.1.5"],
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,14 @@ dependencies = [
     "django-stubs>=1.11.0",
     "typing-extensions>=3.10.0",
     "requests>=2.0.0",
-    "coreapi>=2.0.0",
     "types-requests>=0.1.12",
     "types-PyYAML>=5.4.3",
-    "types-Markdown>=0.1.5",
 ]
 
 extras_require = {
     "compatible-mypy": ["mypy>=0.950,<0.970"],
+    "coreapi": ["coreapi>=2.0.0"],
+    "markdown": ["types-Markdown>=0.1.5"]
 }
 
 setup(


### PR DESCRIPTION
# I have made things!

The coreapi and markdown dependencies in Django REST Framework have been optional for a long time, but installing a stubs package pulls them in regardless. I have moved these to "extras" dependencies. I tested this in my project and it causes no additional mypy inspections.

* [coreapi was deprecated from DRF in 2019](https://www.django-rest-framework.org/community/3.10-announcement/#django-rest-framework-310).
* Markdown support has always been optional.

## Related issues

- Fixes #145
