### PR TITLE
Add 'HEAD' to accepted HTTP verbs list

### DIFF
--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -31,6 +31,7 @@ class MethodMapper(dict):
 
 _LOWER_CASE_HTTP_VERBS: TypeAlias = list[
     Literal[
+        "head",
         "get",
         "post",
         "delete",
@@ -43,6 +44,7 @@ _LOWER_CASE_HTTP_VERBS: TypeAlias = list[
 
 _MIXED_CASE_HTTP_VERBS: TypeAlias = list[
     Literal[
+        "HEAD",
         "GET",
         "POST",
         "DELETE",
@@ -51,6 +53,7 @@ _MIXED_CASE_HTTP_VERBS: TypeAlias = list[
         "TRACE",
         "HEAD",
         "OPTIONS",
+        "head",
         "get",
         "post",
         "delete",

--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -31,20 +31,19 @@ class MethodMapper(dict):
 
 _LOWER_CASE_HTTP_VERBS: TypeAlias = list[
     Literal[
-        "head",
         "get",
         "post",
         "delete",
         "put",
         "patch",
         "trace",
+        "head",
         "options",
     ]
 ]
 
 _MIXED_CASE_HTTP_VERBS: TypeAlias = list[
     Literal[
-        "HEAD",
         "GET",
         "POST",
         "DELETE",
@@ -53,7 +52,6 @@ _MIXED_CASE_HTTP_VERBS: TypeAlias = list[
         "TRACE",
         "HEAD",
         "OPTIONS",
-        "head",
         "get",
         "post",
         "delete",


### PR DESCRIPTION
The `actions` decorator for defining endpoints in DRF seems to support HEAD requests, but the type stubs don't include it as an option.