### PR TITLE
Fix type of data parameter in get test requests

### DIFF
--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -1,4 +1,6 @@
+from collections.abc import Iterable, Mapping
 from typing import Any
+from typing_extensions import TypeAlias
 
 import coreapi
 import requests
@@ -13,6 +15,12 @@ from django.test.client import RequestFactory as DjangoRequestFactory
 from rest_framework.authtoken.models import Token
 from rest_framework.request import Request
 from rest_framework.response import _MonkeyPatchedResponse
+
+_GetDataType: TypeAlias = (
+    Mapping[str, str | bytes | int | Iterable[str | bytes | int]]
+    | Iterable[tuple[str, str | bytes | int | Iterable[str | bytes | int]]]
+    | None
+)
 
 def force_authenticate(
     request: HttpRequest, user: AnonymousUser | AbstractBaseUser | None = ..., token: Token | None = ...
@@ -50,7 +58,7 @@ class APIRequestFactory(DjangoRequestFactory):
     renderer_classes: Any
     def __init__(self, enforce_csrf_checks: bool = ..., **defaults: Any) -> None: ...
     def request(self, **kwargs: Any) -> Request: ...  # type: ignore[override]
-    def get(self, path: str, data: dict[str, Any] | str | None = ..., follow: bool = ..., **extra: Any): ...  # type: ignore[override]
+    def get(self, path: str, data: _GetDataType = ..., follow: bool = ..., **extra: Any): ...  # type: ignore[override]
     def post(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
     def put(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
     def patch(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
@@ -68,7 +76,7 @@ class APIClient(APIRequestFactory, DjangoClient):
     def credentials(self, **kwargs: Any): ...
     def force_authenticate(self, user: AnonymousUser | AbstractBaseUser = ..., token: Token | None = ...) -> None: ...
     def request(self, **kwargs: Any) -> _MonkeyPatchedResponse: ...  # type: ignore[override]
-    def get(self, path: str, data: dict[str, Any] | str | None = ..., follow: bool = ..., **extra: Any): ...  # type: ignore[override]
+    def get(self, path: str, data: _GetDataType = ..., follow: bool = ..., **extra: Any): ...  # type: ignore[override]
     def post(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> _MonkeyPatchedResponse: ...  # type: ignore[override]
     def put(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> _MonkeyPatchedResponse: ...  # type: ignore[override]
     def patch(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> _MonkeyPatchedResponse: ...  # type: ignore[override]

--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -1,6 +1,5 @@
 from collections.abc import Iterable, Mapping
 from typing import Any
-from typing_extensions import TypeAlias
 
 import coreapi
 import requests
@@ -15,6 +14,7 @@ from django.test.client import RequestFactory as DjangoRequestFactory
 from rest_framework.authtoken.models import Token
 from rest_framework.request import Request
 from rest_framework.response import _MonkeyPatchedResponse
+from typing_extensions import TypeAlias
 
 _GetDataType: TypeAlias = (
     Mapping[str, str | bytes | int | Iterable[str | bytes | int]]

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -57,7 +57,6 @@ IGNORED_ERRORS = {
         '"_MonkeyPatchedWSGIResponse" has no attribute "data"',
         '" defined here',
         '" has no attribute "id"',
-        'Argument 2 to "get" of "APIRequestFactory" has incompatible type "Dict[str, object]"',
     ],
     "authentication": [
         'Argument 1 to "post" of "APIClient" has incompatible type "None"; expected "str',
@@ -150,6 +149,7 @@ IGNORED_ERRORS = {
         'expected "Iterable[Any]"',
         'Value of type variable "_MT" of "paginate_queryset" of "CursorPagination" cannot be "object"',
         'Value of type "Union[object, Any]" is not indexable',
+        'Argument 2 to "get" of "APIRequestFactory" has incompatible type "Dict[str, object]"',
     ],
     "test_parsers.py": ['"object" has no attribute', 'Argument 1 to "isnan" has incompatible type'],
     "test_permissions.py": [
@@ -244,6 +244,7 @@ IGNORED_ERRORS = {
     ],
     "test_viewsets.py": [
         '(expression has type "None", variable has type "Request")',
+        'Argument 2 to "get" of "APIRequestFactory" has incompatible type "str"',
         "note: Following member(s) of ",
         "note:     Expected:",
         "note:     Got:",

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -57,6 +57,7 @@ IGNORED_ERRORS = {
         '"_MonkeyPatchedWSGIResponse" has no attribute "data"',
         '" defined here',
         '" has no attribute "id"',
+        'Argument 2 to "get" of "APIRequestFactory" has incompatible type "Dict[str, object]"',
     ],
     "authentication": [
         'Argument 1 to "post" of "APIClient" has incompatible type "None"; expected "str',
@@ -243,6 +244,10 @@ IGNORED_ERRORS = {
     ],
     "test_viewsets.py": [
         '(expression has type "None", variable has type "Request")',
+        "note: Following member(s) of ",
+        "note:     Expected:",
+        "note:     Got:",
+        "note:         def ",
     ],
     "utils.py": ['Invalid signature "Callable[[BadType], Any]"'],
 }


### PR DESCRIPTION
Lists of two-tuples of strings are allowed in the data attribute for get requests

Example of a false-positive needing this fix:
```python
        factory = ApiRequestFactory()
        request = factory.get(users_list_url, data=[("manager", manager1.username), ("manager", manager2.username)])
```