### PR TITLE
Update django-stubs, mypy, pytest-mypy-plugins & fix tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ wheel
 gitpython==3.1.27
 pre-commit==2.20.0
 pytest==7.1.2
-pytest-mypy-plugins==1.9.3
+pytest-mypy-plugins==1.10.1
 djangorestframework==3.13.1
 types-pytz==2022.1.2
-django-stubs==1.12.0
-django-stubs-ext==0.5.0
+django-stubs==1.13.0
+django-stubs-ext==0.7.0
 -e .[compatible-mypy,coreapi,markdown]

--- a/scripts/drf_tests_settings.py
+++ b/scripts/drf_tests_settings.py
@@ -1,7 +1,7 @@
 SECRET_KEY = "1"
 SITE_ID = 1
 
-INSTALLED_APPS = [
+INSTALLED_APPS = (
     "django.contrib.contenttypes",
     "django.contrib.sites",
     "django.contrib.sessions",
@@ -11,4 +11,4 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "rest_framework",
     "rest_framework.authtoken",
-]
+)

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -76,6 +76,7 @@ IGNORED_ERRORS = {
         'Incompatible types in assignment (expression has type "AsView[GenericView]", variable has type "AsView[Callable[[HttpRequest], Any]]")',  # noqa: E501
         'Argument "patterns" to "SchemaGenerator" has incompatible type "List[object]"',
         'Argument 1 to "field_to_schema" has incompatible type "object"; expected "Field[Any, Any, Any, Any]"',
+        'Argument "help_text" to "CharField" has incompatible type "_StrPromise"',
     ],
     "browsable_api": [
         '(expression has type "List[Dict[str, Dict[str, int]]]", base class "GenericAPIView" defined the type as "Union[QuerySet[_MT?], Manager[_MT?], None]")',  # noqa: E501

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=0.950",
-    "django-stubs>=1.11.0",
+    "mypy>=0.980",
+    "django-stubs>=1.13.0",
     "typing-extensions>=3.10.0",
     "requests>=2.0.0",
     "types-requests>=0.1.12",
@@ -28,7 +28,7 @@ dependencies = [
 ]
 
 extras_require = {
-    "compatible-mypy": ["mypy>=0.950,<0.970"],
+    "compatible-mypy": ["mypy>=0.980,<0.990"],
     "coreapi": ["coreapi>=2.0.0"],
     "markdown": ["types-Markdown>=0.1.5"],
 }


### PR DESCRIPTION
All these updates have to be done together, otherwise one dependency is incompatible with another in some way that fails in CI.

Fixes #275, fixes #274