### PR TITLE
Version 1.8.0 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,9 @@ This project is open source and community driven. As such we encourage code cont
 4. Write tests
 5. Update dependencies
 
+Type stubs in `.pyi` files should follow
+[coding conventions from typeshed project](https://github.com/python/typeshed/blob/main/CONTRIBUTING.md#conventions).
+
 ## Tutorials
 
 If you want to start working on this project, you will need to get familiar with python typings.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![Gitter](https://badges.gitter.im/mypy-django/Lobby.svg)](https://gitter.im/mypy-django/Lobby)
 
 
-Mypy stubs for [DRF 3.12.x](https://pypi.org/project/djangorestframework/).
-Supports Python 3.6, 3.7, 3.8 and 3.9.
+Mypy stubs for [Django REST Framework](https://pypi.org/project/djangorestframework/).
+Supports Python 3.7 and up.
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ extras_require = {
 
 setup(
     name="djangorestframework-stubs",
-    version="1.7.0",
+    version="1.8.0",
     description="PEP-484 stubs for django-rest-framework",
     long_description=readme,
     long_description_content_type="text/markdown",
@@ -54,6 +54,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Typing :: Typed",
     ],
 )


### PR DESCRIPTION
@sobolevn Let's make a release, there's a significant number of things in master, including full compatibility with django-stubs 1.13.0, Python 3.10 and mypy 0.991.

I have created draft release notes at https://github.com/typeddjango/djangorestframework-stubs/releases

This PR also tweaks a few places in documentation:

* Updated Python compatibility in setup.py and README.
* Removed DRF version from README -- it has been out of date for a while.
* Added link to typeshed coding conventions that's now enforced by `flake8-pyi`
