### PR TITLE
Fix CI: add typecheck suppression & upgrade flake8-pyi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,11 +24,11 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:
-        - flake8-pyi==22.10.0
+        - flake8-pyi==22.11.0
         types: []
         files: ^.*.pyi?$
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -83,7 +83,10 @@ IGNORED_ERRORS = {
     "browsable_api": [
         'expression has type "List[Dict[str, Dict[str, int]]]"',
     ],
-    "models.py": ['"ForeignKeyTarget" has no attribute "sources"'],
+    "models.py": [
+        '"ForeignKeyTarget" has no attribute "sources"',
+        '"CustomManager" not callable',
+    ],
     "serializers.pyi": [
         'note: "IntegerSerializer" defined here',
     ],


### PR DESCRIPTION
* Added suppression for a new test in upstream
* Upgraded flake8-pyi to be compatible with flake8 v6:

```
    Collecting flake8-pyi==22.10.0
      Downloading flake8_pyi-22.10.0-py37-none-any.whl (24 kB)
    
    The conflict is caused by:
        The user requested flake8 6.0.0 (from /home/runner/.cache/pre-commit/repovn0unijf)
        flake8-pyi 22.10.0 depends on flake8<6.0.0 and >=3.2.1
```