### PR TITLE
Fix encoder and decoder params on JSONField

### DIFF
--- a/rest_framework-stubs/fields.pyi
+++ b/rest_framework-stubs/fields.pyi
@@ -641,8 +641,8 @@ class HStoreField(DictField):
 
 class JSONField(Field[dict[str, Any] | list[dict[str, Any]], dict[str, Any] | list[dict[str, Any]], str, Any]):
     binary: bool
-    encoder: JSONEncoder | None
-    decoder: JSONDecoder | None
+    encoder: type[JSONEncoder] | None
+    decoder: type[JSONDecoder] | None
     def __init__(
         self,
         read_only: bool = ...,
@@ -659,8 +659,8 @@ class JSONField(Field[dict[str, Any] | list[dict[str, Any]], dict[str, Any] | li
         allow_null: bool = ...,
         *,
         binary: bool = ...,
-        encoder: JSONEncoder | None = ...,
-        decoder: JSONDecoder | None = ...,
+        encoder: type[JSONEncoder] | None = ...,
+        decoder: type[JSONDecoder] | None = ...,
     ): ...
 
 class ReadOnlyField(Field): ...


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

params encoder and decoder on JSONField are class types.
Similar example on django_stubs 
https://github.com/typeddjango/django-stubs/blob/b81b1bf3868eaab9fecebdd56ed817ffcb07fad8/django-stubs/db/models/fields/json.pyi#L14-L15