### PR TITLE
Fix CI: Run apt-get update before install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup system dependencies
-        run: sudo apt-get install binutils libproj-dev gdal-bin
+        run: |
+          sudo apt-get update
+          sudo apt-get install binutils libproj-dev gdal-bin
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -56,7 +58,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup system dependencies
-        run: sudo apt-get install binutils libproj-dev gdal-bin
+        run: |
+          sudo apt-get update
+          sudo apt-get install binutils libproj-dev gdal-bin
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Related issues

Same fix as in django-stubs: https://github.com/typeddjango/django-stubs/pull/1313
