### PR TITLE
Fix CI typecheck (add new ignores)

### DIFF
--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -51,7 +51,7 @@ IGNORED_ERRORS = {
         '(expression has type "None", variable has type "ForeignKeyTarget")',
         '"_MonkeyPatchedWSGIResponse" has no attribute "content"',
         '"_MonkeyPatchedWSGIResponse" has no attribute "data"',
-        'note: ".+" defined here',
+        '" defined here',
     ],
     "authentication": [
         'Argument 1 to "post" of "APIClient" has incompatible type "None"; expected "str',

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -51,6 +51,7 @@ IGNORED_ERRORS = {
         '(expression has type "None", variable has type "ForeignKeyTarget")',
         '"_MonkeyPatchedWSGIResponse" has no attribute "content"',
         '"_MonkeyPatchedWSGIResponse" has no attribute "data"',
+        'note: ".+" defined here',
     ],
     "authentication": [
         'Argument 1 to "post" of "APIClient" has incompatible type "None"; expected "str',
@@ -86,9 +87,6 @@ IGNORED_ERRORS = {
     "models.py": [
         '"ForeignKeyTarget" has no attribute "sources"',
         '"CustomManager" not callable',
-    ],
-    "serializers.pyi": [
-        'note: "IntegerSerializer" defined here',
     ],
     "test_authtoken.py": [
         'Item "None" of "Optional[Token]" has no attribute "key"',
@@ -176,6 +174,7 @@ IGNORED_ERRORS = {
         'Item "URLResolver" of "Union[URLPattern, URLResolver]" has no attribute "name"',
         '"None" not callable',
         '"BasenameTestCase" has no attribute "router"',
+        'Unexpected keyword argument "use_regex_path" for "SimpleRouter"',
     ],
     "test_serializer.py": [
         "base class",


### PR DESCRIPTION
Suppressing new typecheck errors that were exposed in #320.

Now ignoring messages like 'note: "SimpleRouter" defined here' and "note: 'IntegerSerializer" defined here' globally because these aren't actually errors, just context.

https://github.com/typeddjango/djangorestframework-stubs/actions/runs/3957376234/jobs/6777713016
