### PR TITLE
Add return type to APIClient.get method

### DIFF
--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -50,7 +50,7 @@ class APIRequestFactory(DjangoRequestFactory):
     renderer_classes: Any
     def __init__(self, enforce_csrf_checks: bool = ..., **defaults: Any) -> None: ...
     def request(self, **kwargs: Any) -> Request: ...  # type: ignore[override]
-    def get(self, path: str, data: dict[str, Any] | str | None = ..., follow: bool = ..., **extra: Any): ...  # type: ignore[override]
+    def get(self, path: str, data: dict[str, Any] | str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
     def post(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
     def put(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
     def patch(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]

--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -68,7 +68,7 @@ class APIClient(APIRequestFactory, DjangoClient):
     def credentials(self, **kwargs: Any): ...
     def force_authenticate(self, user: AnonymousUser | AbstractBaseUser = ..., token: Token | None = ...) -> None: ...
     def request(self, **kwargs: Any) -> _MonkeyPatchedResponse: ...  # type: ignore[override]
-    def get(self, path: str, data: dict[str, Any] | str | None = ..., follow: bool = ..., **extra: Any): ...  # type: ignore[override]
+    def get(self, path: str, data: dict[str, Any] | str | None = ..., follow: bool = ..., **extra: Any) -> _MonkeyPatchedResponse: ...  # type: ignore[override]
     def post(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> _MonkeyPatchedResponse: ...  # type: ignore[override]
     def put(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> _MonkeyPatchedResponse: ...  # type: ignore[override]
     def patch(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> _MonkeyPatchedResponse: ...  # type: ignore[override]

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -176,6 +176,9 @@ IGNORED_ERRORS = {
         '"BasenameTestCase" has no attribute "router"',
         'Unexpected keyword argument "use_regex_path" for "SimpleRouter"',
     ],
+    "test_reverse.py": [
+        'Incompatible types in assignment (expression has type "MockVersioningScheme", variable has type "Optional[BaseVersioning]',  # noqa: E501
+    ],
     "test_serializer.py": [
         "base class",
         '"CharField" has incompatible type "Collection[Any]"',
@@ -228,6 +231,7 @@ IGNORED_ERRORS = {
     "test_versioning.py": [
         "rest_framework.decorators",
         'Argument 1 to "include" has incompatible type "Tuple[List[object], str]"',
+        'Incompatible types in assignment (expression has type "Type[FakeResolverMatch]", variable has type "Optional[ResolverMatch]"',  # noqa: E501
     ],
     "test_viewsets.py": [
         '(expression has type "None", variable has type "Request")',

--- a/tests/typecheck/test_test.yml
+++ b/tests/typecheck/test_test.yml
@@ -33,9 +33,16 @@
     from django.urls import URLPattern, URLResolver
     from rest_framework import test, status
 
-    class MyTest(test.APITestCase):
+    client = test.APIClient()
+    response = client.get('/', format="json")
+    reveal_type(response) # N: Revealed type is "rest_framework.response._MonkeyPatchedResponse"
 
-        def test_example(self) -> None:
-            response = self.client.get('/', format="json")
-            reveal_type(response) # N: Revealed type is "rest_framework.response._MonkeyPatchedResponse"
-            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+- case: test_api_client_factory_get
+  main: |
+    from typing import Union, List
+    from django.urls import URLPattern, URLResolver
+    from rest_framework import test, status
+
+    factory = test.APIRequestFactory()
+    request = factory.get("/")
+    reveal_type(request) # N: Revealed type is "rest_framework.request.Request"

--- a/tests/typecheck/test_test.yml
+++ b/tests/typecheck/test_test.yml
@@ -26,19 +26,3 @@
             reveal_type(self.client) # N: Revealed type is "django.test.client.Client"
             response = self.client.get('/', format="json")
             self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-- case: test_api_client_get
-  main: |
-    from rest_framework import test
-
-    client = test.APIClient()
-    response = client.get('/', format="json")
-    reveal_type(response) # N: Revealed type is "rest_framework.response._MonkeyPatchedResponse"
-
-- case: test_api_client_factory_get
-  main: |
-    from rest_framework import test
-
-    factory = test.APIRequestFactory()
-    request = factory.get("/")
-    reveal_type(request) # N: Revealed type is "rest_framework.request.Request"

--- a/tests/typecheck/test_test.yml
+++ b/tests/typecheck/test_test.yml
@@ -26,3 +26,16 @@
             reveal_type(self.client) # N: Revealed type is "django.test.client.Client"
             response = self.client.get('/', format="json")
             self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+- case: test_api_client_get
+  main: |
+    from typing import Union, List
+    from django.urls import URLPattern, URLResolver
+    from rest_framework import test, status
+
+    class MyTest(test.APITestCase):
+
+        def test_example(self) -> None:
+            response = self.client.get('/', format="json")
+            reveal_type(response) # N: Revealed type is "rest_framework.response._MonkeyPatchedResponse"
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/tests/typecheck/test_test.yml
+++ b/tests/typecheck/test_test.yml
@@ -29,9 +29,7 @@
 
 - case: test_api_client_get
   main: |
-    from typing import Union, List
-    from django.urls import URLPattern, URLResolver
-    from rest_framework import test, status
+    from rest_framework import test
 
     client = test.APIClient()
     response = client.get('/', format="json")
@@ -39,9 +37,7 @@
 
 - case: test_api_client_factory_get
   main: |
-    from typing import Union, List
-    from django.urls import URLPattern, URLResolver
-    from rest_framework import test, status
+    from rest_framework import test
 
     factory = test.APIRequestFactory()
     request = factory.get("/")


### PR DESCRIPTION
# I have made things!

Added return type to `rest_framework.test.APIClient`.

Typing for this class was added in https://github.com/typeddjango/djangorestframework-stubs/commit/cf9d492ec01f99e9a3fa89558aa1fbf1a749bc22 and return type was already missing.

Did not find a reason why it should not be there?

## Related issues

Closes #327
