### PR TITLE
CI: Freeze DRF commit used in typecheck_tests and types-requests/types-urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ pytest==7.2.1
 pytest-mypy-plugins==1.10.1
 djangorestframework==3.14.0
 types-pytz==2022.7.1.0
+types-requests==2.28.11.8
+types-urllib3==1.26.25.4
 django-stubs==1.13.0
 django-stubs-ext==0.7.0
 -e .[compatible-mypy,coreapi,markdown]

--- a/scripts/git_helpers.py
+++ b/scripts/git_helpers.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Optional
 
 from git import RemoteProgress, Repo

--- a/scripts/git_helpers.py
+++ b/scripts/git_helpers.py
@@ -14,7 +14,7 @@ class ProgressPrinter(RemoteProgress):
         print(self._cur_line)
 
 
-def checkout_target_tag(drf_version: Optional[str]) -> Path:
+def git_checkout_drf(commit_ref: Optional[str] = None) -> None:
     if not DRF_SOURCE_DIRECTORY.exists():
         DRF_SOURCE_DIRECTORY.mkdir(exist_ok=True, parents=False)
         repository = Repo.clone_from(
@@ -27,4 +27,4 @@ def checkout_target_tag(drf_version: Optional[str]) -> Path:
     else:
         repository = Repo(DRF_SOURCE_DIRECTORY)
         repository.remote("origin").pull("master", progress=ProgressPrinter(), depth=100)
-    repository.git.checkout(drf_version or "master")
+    repository.git.checkout(commit_ref or "master")

--- a/scripts/stubgen-drf.py
+++ b/scripts/stubgen-drf.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 
 from mypy.stubgen import generate_stubs, parse_options
 
-from scripts.git_helpers import checkout_target_tag
+from scripts.git_helpers import git_checkout_drf
 from scripts.paths import DRF_SOURCE_DIRECTORY
 
 if __name__ == "__main__":
@@ -12,6 +12,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if DRF_SOURCE_DIRECTORY.exists():
         shutil.rmtree(DRF_SOURCE_DIRECTORY)
-    checkout_target_tag(args.drf_version)
+    git_checkout_drf(args.drf_version)
     stubgen_options = parse_options([f"{DRF_SOURCE_DIRECTORY}", "-o=stubgen"])
     generate_stubs(stubgen_options)

--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -7,8 +7,12 @@ from collections import defaultdict
 from distutils import dir_util, spawn
 from typing import Dict, List, Pattern, Union
 
-from scripts.git_helpers import checkout_target_tag
+from scripts.git_helpers import git_checkout_drf
 from scripts.paths import DRF_SOURCE_DIRECTORY, PROJECT_DIRECTORY, STUBS_DIRECTORY
+
+# django-rest-framework commit hash to check against (ignored with --drf_version)
+# This should be updated periodically or after every DRF release.
+DRF_GIT_REF = "22d206c1e0dbc03840c4d190f7eda537c0f2010a"
 
 IGNORED_MODULES = []
 MOCK_OBJECTS = [
@@ -284,7 +288,7 @@ if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("--drf_version", required=False)
     args = parser.parse_args()
-    checkout_target_tag(args.drf_version)
+    git_checkout_drf(args.drf_version or DRF_GIT_REF)
     if sys.version_info[1] > 7:
         shutil.copytree(STUBS_DIRECTORY, DRF_SOURCE_DIRECTORY / "rest_framework", dirs_exist_ok=True)
     else:


### PR DESCRIPTION
* Freeze DRF git commit hash used in CI.
* Freeze versions of types-requests and types-urllib3 since they are already incompatible with mypy 0.991.

FYI @christianbundy.

As discussed in https://github.com/typeddjango/djangorestframework-stubs/pull/339#issuecomment-1420766315, using the latest master branch state in typecheck_tests frequently causes CI failures to pop up in unrelated pull requests.

> I've looked at each error, and checked if it's something we're missing in stubs or a false positive. Usually it's a false positive, or some new feature that has been merged in DRF but will be in the next version (e.g. https://github.com/typeddjango/djangorestframework-stubs/pull/338).
>
> But it's annoying and confusing, especially for new contributors, when CI checks start to fail due to unrelated changes. So I've been thinking that we may want to freeze the git commit hash that we check (like is already done in django-stubs).
>
> But the downside is that then we would have to periodically update this hash, something that's been a bit neglected in django-stubs.
