### PR TITLE
Run pre-commit isort on pyi files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,14 @@ repos:
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
     hooks:
       - id: isort
+        name: isort (python)
+      - id: isort
+        name: isort (pyi)
+        types: [pyi]
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:

--- a/rest_framework-stubs/exceptions.pyi
+++ b/rest_framework-stubs/exceptions.pyi
@@ -1,12 +1,11 @@
 from collections.abc import Sequence
 from typing import Any
 
-from typing_extensions import TypeAlias
-
 from django.http import HttpRequest, JsonResponse
 from django_stubs_ext import StrOrPromise
 from rest_framework.renderers import BaseRenderer
 from rest_framework.request import Request
+from typing_extensions import TypeAlias
 
 def _get_error_details(data: Any, default_code: str | None = ...) -> Any: ...
 def _get_codes(detail: Any) -> Any: ...

--- a/rest_framework-stubs/generics.pyi
+++ b/rest_framework-stubs/generics.pyi
@@ -3,7 +3,6 @@ from typing import Any, Protocol, TypeVar
 
 from django.db.models import Manager, Model
 from django.db.models.query import QuerySet
-
 from rest_framework import mixins, views
 from rest_framework.filters import BaseFilterBackend
 from rest_framework.pagination import BasePagination

--- a/rest_framework-stubs/mixins.pyi
+++ b/rest_framework-stubs/mixins.pyi
@@ -1,7 +1,6 @@
 from typing import Any, TypeVar
 
 from django.db.models import Model
-
 from rest_framework.generics import UsesQuerySet
 from rest_framework.request import Request
 from rest_framework.response import Response

--- a/rest_framework-stubs/permissions.pyi
+++ b/rest_framework-stubs/permissions.pyi
@@ -1,10 +1,10 @@
 from collections.abc import Sequence
 from typing import Any, Protocol, Union  # noqa: Y037  # https://github.com/python/mypy/issues/12392
-from typing_extensions import TypeAlias
 
 from django.db.models import Model, QuerySet
 from rest_framework.request import Request
 from rest_framework.views import APIView
+from typing_extensions import TypeAlias
 
 SAFE_METHODS: Sequence[str]
 

--- a/rest_framework-stubs/relations.pyi
+++ b/rest_framework-stubs/relations.pyi
@@ -1,8 +1,8 @@
 from collections import OrderedDict
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, Generic, TypeVar
-from _typeshed import Self
 
+from _typeshed import Self
 from django.db.models import Manager, Model, QuerySet
 from rest_framework.fields import Field, Option
 from rest_framework.request import Request

--- a/rest_framework-stubs/renderers.pyi
+++ b/rest_framework-stubs/renderers.pyi
@@ -1,5 +1,5 @@
-from json import JSONEncoder
 from collections.abc import Iterable, Mapping, Sequence
+from json import JSONEncoder
 from typing import Any
 
 from django import forms

--- a/rest_framework-stubs/request.pyi
+++ b/rest_framework-stubs/request.pyi
@@ -1,7 +1,6 @@
-from contextlib import contextmanager
-from types import TracebackType
 from collections.abc import Iterator, Sequence
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, contextmanager
+from types import TracebackType
 from typing import Any
 
 from django.contrib.auth.base_user import AbstractBaseUser

--- a/rest_framework-stubs/response.pyi
+++ b/rest_framework-stubs/response.pyi
@@ -2,10 +2,9 @@ from collections.abc import Mapping
 from typing import Any
 
 from django.template.base import Template
-from django.test.utils import ContextList
 from django.template.response import SimpleTemplateResponse
+from django.test.utils import ContextList
 from django.urls import ResolverMatch
-
 from rest_framework.request import Request
 from rest_framework.test import APIClient
 

--- a/rest_framework-stubs/schemas/generators.pyi
+++ b/rest_framework-stubs/schemas/generators.pyi
@@ -1,13 +1,13 @@
-from types import ModuleType
 from collections.abc import Iterable, Sequence
+from types import ModuleType
 from typing import Any
-from typing_extensions import TypeAlias
 
 from django.db.models.base import Model
 from rest_framework.compat import coreapi
 from rest_framework.request import Request
 from rest_framework.urlpatterns import _AnyURL
 from rest_framework.views import APIView
+from typing_extensions import TypeAlias
 
 def common_path(paths: Iterable[str]) -> str: ...
 def get_pk_name(model: type[Model]) -> str: ...

--- a/rest_framework-stubs/urlpatterns.pyi
+++ b/rest_framework-stubs/urlpatterns.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Sequence
-from typing_extensions import TypeAlias
 
 from django.urls.resolvers import URLPattern, URLResolver
+from typing_extensions import TypeAlias
 
 _AnyURL: TypeAlias = URLPattern | URLResolver
 

--- a/rest_framework-stubs/validators.pyi
+++ b/rest_framework-stubs/validators.pyi
@@ -1,10 +1,10 @@
 from collections.abc import Callable, Container, Iterable, MutableMapping
-from typing import Any, TypeVar, Protocol
-from typing_extensions import TypeAlias
+from typing import Any, Protocol, TypeVar
 
 from django.db.models import Model, QuerySet
 from rest_framework.fields import Field
 from rest_framework.serializers import BaseSerializer
+from typing_extensions import TypeAlias
 
 _T = TypeVar("_T", bound=Model)
 _V = TypeVar("_V", contravariant=True)

--- a/rest_framework-stubs/viewsets.pyi
+++ b/rest_framework-stubs/viewsets.pyi
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 from collections.abc import Callable
 from typing import Any
-from typing_extensions import TypeAlias
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
@@ -10,6 +9,7 @@ from rest_framework.decorators import ViewSetAction
 from rest_framework.generics import _MT_co
 from rest_framework.request import Request
 from rest_framework.views import AsView, GenericView
+from typing_extensions import TypeAlias
 
 def _is_extra_action(attr: Any) -> bool: ...
 


### PR DESCRIPTION
Pre-commit isort was ignoring `.pyi` files, this fixes that.

## Related issues

Similar to django-stubs PR https://github.com/typeddjango/django-stubs/pull/664
