### PR TITLE
Update package metadata: release notes URL, classifiers, maintainer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 import os
+from typing import List
 
 from setuptools import find_packages, setup
 
 
-def find_stub_files(name):
+def find_stub_files(name: str) -> List[str]:
     result = []
     for root, _dirs, files in os.walk(name):
         for file in files:
@@ -42,6 +43,8 @@ setup(
     url="https://github.com/typeddjango/djangorestframework-stubs",
     author="Maksim Kurnikov",
     author_email="maxim.kurnikov@gmail.com",
+    maintainer="Marti Raudsepp",
+    maintainer_email="marti@juffo.org",
     license="MIT",
     install_requires=dependencies,
     extras_require=extras_require,
@@ -55,6 +58,11 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Typing :: Typed",
+        "Framework :: Django",
     ],
+    project_urls={
+        "Release notes": "https://github.com/typeddjango/djangorestframework-stubs/releases",
+    },
 )


### PR DESCRIPTION
Harmonized with django-stubs `setup.py`

* Added Release notes URL to package metadata (related: https://github.com/typeddjango/django-stubs/pull/365)
* Added classifiers for Python 3.11 and Django framework
* Added myself as the de-facto maintainer here
* Added type hints
