### PR TITLE
Release script: Also clean build directories before a build

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,6 +6,7 @@ then
   if [[ "$VIRTUAL_ENV" != ""  ]]
   then
     pip install --upgrade setuptools wheel twine
+    rm -rf dist/ build/
     python setup.py sdist bdist_wheel
     twine upload dist/*
     rm -rf dist/ build/


### PR DESCRIPTION
To avoid future incidents like https://github.com/typeddjango/djangorestframework-stubs/issues/362

See https://github.com/typeddjango/djangorestframework-stubs/issues/362#issuecomment-1441790233 for the full background about how this happened.
