### PR TITLE
Fix BaseMetadata.determine_metadata type hint

### DIFF
--- a/rest_framework-stubs/metadata.pyi
+++ b/rest_framework-stubs/metadata.pyi
@@ -7,7 +7,7 @@ from rest_framework.utils.field_mapping import ClassLookupDict
 from rest_framework.views import APIView
 
 class BaseMetadata:
-    def determine_metadata(self, request: Request, view: APIView) -> dict[str, Any]: ...
+    def determine_metadata(self, request: Request, view: APIView) -> Any: ...
 
 class SimpleMetadata(BaseMetadata):
     label_lookup: ClassLookupDict[type[serializers.Field], str]


### PR DESCRIPTION
The return value of `BaseMetadata.determine_metadata()` is passed to `Response.data`, which accepts `Any` (In my case, I was trying to return `None`, for empty response body).