### PR TITLE
Run pre-commit only on pre-commit.ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,25 +30,6 @@ jobs:
       - name: Run mypy on stubs
         run: mypy --cache-dir=/dev/null --no-incremental rest_framework-stubs
 
-  lint:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10']
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install -U pip setuptools wheel
-          pip install -r ./requirements.txt
-
-      - name: Run pre-commit
-        run: pre-commit install && pre-commit run --all-files
-
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Similar to https://github.com/typeddjango/django-stubs/pull/1250

Since we now run pre-commit checks on pre-commit.ci infra (#360), running it on GitHub Actions CI is redundant.
