### PR TITLE
Changed from list to abstract Sequence type for http verbs

### DIFF
--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -29,7 +29,7 @@ class MethodMapper(dict):
     def options(self, func: _View) -> _View: ...
     def trace(self, func: _View) -> _View: ...
 
-_LOWER_CASE_HTTP_VERBS: TypeAlias = list[
+_LOWER_CASE_HTTP_VERBS: TypeAlias = Sequence[
     Literal[
         "get",
         "post",
@@ -42,7 +42,7 @@ _LOWER_CASE_HTTP_VERBS: TypeAlias = list[
     ]
 ]
 
-_MIXED_CASE_HTTP_VERBS: TypeAlias = list[
+_MIXED_CASE_HTTP_VERBS: TypeAlias = Sequence[
     Literal[
         "GET",
         "POST",

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -41,3 +41,16 @@
         permission_classes([IsAuthenticated & Permission])
         permission_classes([IsAuthenticated | Permission])
         permission_classes([~Permission])
+
+- case: method_decorator
+  main: |
+    from rest_framework import viewsets
+    from rest_framework.decorators import action
+
+    class MyView(viewsets.ViewSet):
+      
+      @action(methods=("get",), detail=False)
+      def view_func_1(request): ...
+
+      @action(methods=["post",], detail=False)
+      def view_func_2(request): ...

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -48,7 +48,7 @@
     from rest_framework.decorators import action
 
     class MyView(viewsets.ViewSet):
-      
+
       @action(methods=("get",), detail=False)
       def view_func_1(request): ...
 


### PR DESCRIPTION
Allows method decorator to not fail on tuple, as there is no reason to have `methods` mutable

# I have made things!
Changed from `list` to abstract `Sequence` type for http verbs. while documentation uses `list` for declaring methods for action decorator, the actual implementation only uses fact that methods are `Iterable`, and they rebuild this list all over again for normalisation. 

Documentation: https://www.django-rest-framework.org/api-guide/viewsets/#viewset-actions