### PR TITLE
CI: Always install django-stubs from git master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ djangorestframework==3.14.0
 types-pytz==2023.3.0.0
 types-requests==2.30.0.0
 types-urllib3==1.26.25.13
-django-stubs==4.2.0
+git+https://github.com/typeddjango/django-stubs
 django-stubs-ext==4.2.0
 -e .[compatible-mypy,coreapi,markdown]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ types-pytz==2023.3.0.0
 types-requests==2.30.0.0
 types-urllib3==1.26.25.13
 git+https://github.com/typeddjango/django-stubs
-django-stubs-ext==4.2.0
+git+https://github.com/typeddjango/django-stubs#subdirectory=django_stubs_ext
 -e .[compatible-mypy,coreapi,markdown]


### PR DESCRIPTION
It's not uncommon to need to coordinate changes between django-stubs and djangorestframework-stubs projects. E.g. I need to make some changes in django-stubs first and then also make a similar change here that builds on django-stubs. Happens particularly often with mypy updates like #416.

So I propose making django-stubs permanently a git dependency in CI and development `requirements.txt`
