### PR TITLE
CI: Replace isort with Ruff import sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .idea/
 .mypy_cache/
 .pytest_cache/
+.ruff_cache/
 .venv/
 __pycache__/
 drf_source/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,14 +15,11 @@ repos:
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.270
     hooks:
-      - id: isort
-        name: isort (python)
-      - id: isort
-        name: isort (pyi)
-        types: [pyi]
+      - id: ruff
+        args: ["--fix", "--fixable=I001", "--exit-non-zero-on-fix"]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,21 @@
 line-length = 120
 include = '\.pyi?$'
 
-[tool.isort]
-line_length = 120
-multi_line_output = 3
-include_trailing_comma = true
-profile = 'black'
+[tool.ruff]
+# Adds to default excludes: https://ruff.rs/docs/settings/#exclude
+extend-exclude = [
+    "drf_source",
+    "stubgen",
+    "out",
+]
+line-length = 120
+target-version = "py38"
+select = [
+    "I",    # isort
+]
+
+[tool.ruff.isort]
+split-on-trailing-comma = false
 
 [build-system]
 requires = ["setuptools<64", "wheel"]


### PR DESCRIPTION
This is the first step in adopting Ruff: https://beta.ruff.rs/

Ruff is faster and will allow us to perform more fixes and checks in the future (e.g. replacing flake8, pyupgrade, auto-removing unused imports, etc).

## Related issues

* django-stubs: https://github.com/typeddjango/django-stubs/pull/1507
