### PR TITLE
CI: Auto-remove unused imports using Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v0.0.270
     hooks:
       - id: ruff
-        args: ["--fix", "--fixable=I001", "--exit-non-zero-on-fix"]
+        args: ["--fix", "--exit-non-zero-on-fix"]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,6 @@ select = [
     "I",    # isort
     "F401", # Unused imports
 ]
-fixable = [
-    "I001",
-    "F401",
-]
 
 [tool.ruff.isort]
 split-on-trailing-comma = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ line-length = 120
 target-version = "py38"
 select = [
     "I",    # isort
+    "F401", # Unused imports
+]
+fixable = [
+    "I001",
+    "F401",
 ]
 
 [tool.ruff.isort]

--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -2,13 +2,9 @@ from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMappin
 from typing import Any, Generic, NoReturn, TypeVar
 
 from _typeshed import Self
-from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import models
-from django.db.models import DurationField as ModelDurationField
 from django.db.models import Manager, Model, QuerySet
-from django.db.models.fields import Field as DjangoModelField
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
 from django_stubs_ext import StrOrPromise
 from rest_framework.exceptions import APIException as APIException
 from rest_framework.exceptions import AuthenticationFailed as AuthenticationFailed


### PR DESCRIPTION
Ruff can automagically clean up unused imports.

## Related issues

* django-stubs https://github.com/typeddjango/django-stubs/pull/1508
