### PR TITLE
CI: Add suppressions due to django-stubs changes

### DIFF
--- a/scripts/typecheck_tests.py
+++ b/scripts/typecheck_tests.py
@@ -188,6 +188,8 @@ IGNORED_ERRORS = {
     ],
     "test_response.py": [
         'Argument 2 to "get" of "Client" has incompatible type "**Dict[str, str]"',
+        '"Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance',
+        'Consider using "Mapping" instead, which is covariant in the value type',
     ],
     "test_routers.py": [
         'expression has type "List[RouterTestModel]"',


### PR DESCRIPTION
Fixes new errors that appeared after django-stubs changes.

```
drf_source/tests/test_response.py:259: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
drf_source/tests/test_response.py:259: note: Consider using "Mapping" instead, which is covariant in the value type
drf_source/tests/test_response.py:269: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
drf_source/tests/test_response.py:269: note: Consider using "Mapping" instead, which is covariant in the value type
drf_source/tests/test_response.py:278: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
drf_source/tests/test_response.py:278: note: Consider using "Mapping" instead, which is covariant in the value type
```

## Related issues
