### PR TITLE
Update compatible-mypy to 1.4.x

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -5,8 +5,11 @@ check_untyped_defs = True
 show_traceback = True
 allow_redefinition = True
 incremental = True
-show_error_codes = False
 disable_error_code = empty-body
+# TODO: update our test error messages to match new mypy output
+show_error_codes = False
+force_uppercase_builtins = True
+force_union_syntax = True
 
 plugins =
     mypy_django_plugin.main,

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,11 +5,8 @@ check_untyped_defs = True
 show_traceback = True
 allow_redefinition = True
 incremental = True
-disable_error_code = empty-body
-# TODO: update our test error messages to match new mypy output
 show_error_codes = False
-force_uppercase_builtins = True
-force_union_syntax = True
+disable_error_code = empty-body
 
 plugins =
     mypy_django_plugin.main,

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,9 @@ dependencies = [
     "types-PyYAML>=5.4.3",
 ]
 
+# Keep compatible-mypy major.minor version pinned to what we use in CI (requirements.txt)
 extras_require = {
-    "compatible-mypy": ["mypy>=1.3.0,<1.4"],
+    "compatible-mypy": ["mypy==1.4.*"],
     "coreapi": ["coreapi>=2.0.0"],
     "markdown": ["types-Markdown>=0.1.5"],
 }

--- a/tests/plugins.ini
+++ b/tests/plugins.ini
@@ -1,10 +1,13 @@
 [mypy]
 check_untyped_defs = True
-show_error_codes = False
 disable_error_code = empty-body
 plugins =
     mypy_django_plugin.main,
     mypy_drf_plugin.main
+# TODO: update our test error messages to match new mypy output
+show_error_codes = False
+force_uppercase_builtins = True
+force_union_syntax = True
 
 [mypy-coreapi]
 ignore_missing_imports = True


### PR DESCRIPTION
Added settings `force_uppercase_builtins` and `force_union_syntax` to keep our tests passing without mass edits to test files.

## Related issues

Similar to django-stubs PRs:

* https://github.com/typeddjango/django-stubs/pull/1572
* https://github.com/typeddjango/django-stubs/pull/1588

Closes #430