### PR TITLE
Fix test broken by django-stubs 4.2.4

### DIFF
--- a/tests/typecheck/test_views.yml
+++ b/tests/typecheck/test_views.yml
@@ -10,15 +10,22 @@
 - case: test_destroy_api_view
   main: |
     from rest_framework import generics
-    from django.db.models import Model
-
-    class MyModel(Model):
-        pass
+    from myapp.models import MyModel
 
     class MyView(generics.DestroyAPIView):
         queryset = MyModel.objects.all()
 
         def perform_destroy(self, instance: MyModel) -> None: ...
+  installed_apps:
+      - myapp
+  files:
+      -   path: myapp/__init__.py
+      -   path: myapp/models.py
+          content: |
+              from django.db import models
+              class MyModel(models.Model):
+                  pass
+
 
 - case: test_build_api_request
   main: |


### PR DESCRIPTION
**Problem**

The new version of Django stubs broke a test.

**Solution**

Fix it. It looks like we need to expose the model in `models` for it to get `.objects`.