### PR TITLE
Specify that Request.parser_context can never be None

### DIFF
--- a/rest_framework-stubs/request.pyi
+++ b/rest_framework-stubs/request.pyi
@@ -45,7 +45,7 @@ class Request(HttpRequest):
     parsers: Sequence[BaseParser] | None
     authenticators: Sequence[BaseAuthentication | ForcedAuthentication] | None
     negotiator: BaseContentNegotiation | None
-    parser_context: dict[str, Any] | None
+    parser_context: dict[str, Any]
     version: str | None
     versioning_scheme: BaseVersioning | None
     _request: HttpRequest


### PR DESCRIPTION
Closes #473.