### PR TITLE
Allow None for Pagination.template attribute

### DIFF
--- a/rest_framework-stubs/pagination.pyi
+++ b/rest_framework-stubs/pagination.pyi
@@ -64,7 +64,7 @@ class PageNumberPagination(BasePagination):
     page_size: int | None
     page: Page | None
     request: Request | None
-    template: str
+    template: str | None
     def paginate_queryset(
         self, queryset: QuerySet[_MT], request: Request, view: APIView | None = ...
     ) -> list[_MT] | None: ...
@@ -88,7 +88,7 @@ class LimitOffsetPagination(BasePagination):
     offset_query_param: str
     offset: int | None
     request: Request | None
-    template: str
+    template: str | None
     def paginate_queryset(
         self, queryset: QuerySet[_MT], request: Request, view: APIView | None = ...
     ) -> list[_MT] | None: ...
@@ -116,7 +116,7 @@ class CursorPagination(BasePagination):
     page_size: int | None
     page: list[Any] | None
     previous_position: str | None
-    template: str
+    template: str | None
     def paginate_queryset(
         self, queryset: QuerySet[_MT], request: Request, view: APIView | None = ...
     ) -> list[_MT] | None: ...


### PR DESCRIPTION
According to documentation https://www.django-rest-framework.org/api-guide/pagination/#configuration

> template - The name of a template to use when rendering pagination controls in the browsable API. May be overridden to modify the rendering style, **or set to None to disable HTML pagination controls** completely.