### PR TITLE
Migrate from flake8 to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,14 +21,6 @@ repos:
     rev: 23.9.1
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-        - flake8-pyi==22.11.0
-        types: []
-        files: ^.*.pyi?$
 
 ci:
     autofix_commit_msg: '[pre-commit.ci] auto fixes from pre-commit.com hooks'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ pre-commit install
 
 ### Testing and Linting
 
-We use `mypy`, `pytest`, `flake8`, and `black` for quality control. All tools except pytest are executed using pre-commit when you make a commit.
+We use `mypy`, `pytest`, `ruff`, and `black` for quality control. All tools except pytest are executed using pre-commit when you make a commit.
 To ensure there are not formatting or typing issues in the entire repository you can run:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 120
 include = '\.pyi?$'
 
 [tool.ruff]
-# Adds to default excludes: https://ruff.rs/docs/settings/#exclude
+# Adds to default excludes: https://docs.astral.sh/ruff/settings/#exclude
 extend-exclude = [
     ".*/",
     "drf_source",
@@ -12,7 +12,7 @@ extend-exclude = [
 ]
 line-length = 120
 target-version = "py38"
-# See Rules in Ruff documentation: https://beta.ruff.rs/docs/rules/
+# See Rules in Ruff documentation: https://docs.astral.sh/ruff/rules/
 select = [
     "B",        # bugbear
     "E",        # pycodestyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ include = '\.pyi?$'
 [tool.ruff]
 # Adds to default excludes: https://ruff.rs/docs/settings/#exclude
 extend-exclude = [
+    ".*/",
     "drf_source",
     "stubgen",
     "out",
@@ -13,11 +14,38 @@ line-length = 120
 target-version = "py38"
 # See Rules in Ruff documentation: https://beta.ruff.rs/docs/rules/
 select = [
-    "I",    # isort
-    "F401", # Unused imports
-    "UP",   # pyupgrade
-    "TID",  # flake8-tidy-imports
+    "B",        # bugbear
+    "E",        # pycodestyle
+    "F",        # pyflakes
+    "INP",      # flake8-tidy-imports
+    "W",        # pycodestyle
+    "I",        # isort
+    "UP",       # pyupgrade
+    "TID251",   # Disallowed imports (flake8-tidy-imports.banned-api)
+    "PYI",      # flake8-pyi
+    "RUF100",   # Equivalent to flake8-noqa NQA103
+    "PGH004",   # Equivalent to flake8-noqa NQA104
+    "PGH003",   # Disallowed blanket `type: ignore` annotations.
 ]
+ignore = ["PYI021", "PYI024", "PYI041", "PYI043"]
+
+[tool.ruff.per-file-ignores]
+"*.pyi" = [
+    "B",
+    "E501",
+    "E741",
+    "E743",
+    "F403", # Use wildcard import
+    "F405",
+    "F822",
+    "F821",
+    "PYI026",  # TODO fix these errors
+    "PGH003",  # TODO fix these errors
+    "PYI002",  # TODO fix these errors
+]
+#"tests/*.py" = ["INP001"]
+#"ext/tests/*.py" = ["INP001"]
+#"setup.py" = ["INP001"]
 
 [tool.ruff.flake8-tidy-imports.banned-api]
 "_typeshed.Self".msg = "Use typing_extensions.Self (PEP 673) instead."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,6 @@ ignore = ["PYI021", "PYI024", "PYI041", "PYI043"]
     "PGH003",  # TODO fix these errors
     "PYI002",  # TODO fix these errors
 ]
-#"tests/*.py" = ["INP001"]
-#"ext/tests/*.py" = ["INP001"]
-#"setup.py" = ["INP001"]
 
 [tool.ruff.flake8-tidy-imports.banned-api]
 "_typeshed.Self".msg = "Use typing_extensions.Self (PEP 673) instead."

--- a/rest_framework-stubs/compat.pyi
+++ b/rest_framework-stubs/compat.pyi
@@ -1,6 +1,5 @@
 from typing import Any
 
-import requests  # noqa: F401
 from django.db.models import QuerySet
 
 try:

--- a/rest_framework-stubs/fields.pyi
+++ b/rest_framework-stubs/fields.pyi
@@ -17,7 +17,7 @@ from rest_framework.validators import Validator
 from typing_extensions import Self, TypeAlias
 
 class _Empty(Enum):
-    sentinel = 0  # noqa: Y015
+    sentinel = 0
 
 empty: Final = _Empty.sentinel
 
@@ -329,7 +329,7 @@ class DecimalField(Field[Decimal, int | float | str | Decimal, str, Any]):
     min_value: Decimal | int | float | None
     localize: bool
     rounding: str | None
-    max_whole_digits = int | None  # noqa: Y026
+    max_whole_digits: int | None
     def __init__(
         self,
         max_digits: int | None,

--- a/rest_framework-stubs/generics.pyi
+++ b/rest_framework-stubs/generics.pyi
@@ -35,7 +35,7 @@ class GenericAPIView(views.APIView, UsesQuerySet[_MT_co]):
     serializer_class: type[BaseSerializer] | None
     lookup_field: str
     lookup_url_kwarg: str | None
-    filter_backends: Sequence[type[BaseFilterBackend] | type[BaseFilterProtocol[_MT_co]]]
+    filter_backends: Sequence[type[BaseFilterBackend | BaseFilterProtocol[_MT_co]]]
     pagination_class: type[BasePagination] | None
     def get_object(self) -> _MT_co: ...
     def get_serializer(self, *args: Any, **kwargs: Any) -> BaseSerializer[_MT_co]: ...

--- a/rest_framework-stubs/permissions.pyi
+++ b/rest_framework-stubs/permissions.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Sequence
-from typing import Any, Protocol  # noqa: Y037  # https://github.com/python/mypy/issues/12392
+from typing import Any, Protocol
 
 from django.db.models import Model, QuerySet
 from rest_framework.request import Request

--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -19,7 +19,7 @@ from rest_framework.exceptions import Throttled as Throttled
 from rest_framework.exceptions import UnsupportedMediaType as UnsupportedMediaType
 from rest_framework.exceptions import ValidationError as ValidationError
 from rest_framework.fields import BooleanField as BooleanField
-from rest_framework.fields import CharField as CharField  # noqa: F401
+from rest_framework.fields import CharField as CharField
 from rest_framework.fields import ChoiceField as ChoiceField
 from rest_framework.fields import CreateOnlyDefault as CreateOnlyDefault
 from rest_framework.fields import CurrentUserDefault as CurrentUserDefault


### PR DESCRIPTION
## Related issues

Similar to change in django-stubs: https://github.com/typeddjango/django-stubs/pull/1718. Thanks to @GabDug for the original PR there.
