### PR TITLE
Version 3.14.4 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md") as f:
 
 dependencies = [
     "mypy>=0.991",
-    "django-stubs>=4.2.4",
+    "django-stubs>=4.2.5",
     "typing-extensions>=3.10.0",
     "requests>=2.0.0",
     "types-requests>=0.1.12",
@@ -37,7 +37,7 @@ extras_require = {
 
 setup(
     name="djangorestframework-stubs",
-    version="3.14.3",
+    version="3.14.4",
     description="PEP-484 stubs for django-rest-framework",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Tests will be failing until `django-stubs` PR is merged.

* Depends on https://github.com/typeddjango/django-stubs/pull/1777
* Related https://github.com/typeddjango/django-stubs/issues/1740