### PR TITLE
Drop hard dependency on mypy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ djangorestframework==3.14.0
 types-pytz==2023.3.1.1
 types-requests==2.31.0.10
 types-urllib3==1.26.25.14
-git+https://github.com/typeddjango/django-stubs#egg=django-stubs[compatible-mypy]
-git+https://github.com/typeddjango/django-stubs#subdirectory=ext
+django-stubs[compatible-mypy] @ git+https://github.com/typeddjango/django-stubs
+django-stubs-ext @ git+https://github.com/typeddjango/django-stubs#subdirectory=ext
 -e .[compatible-mypy,coreapi,markdown]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ djangorestframework==3.14.0
 types-pytz==2023.3.1.1
 types-requests==2.31.0.10
 types-urllib3==1.26.25.14
-git+https://github.com/typeddjango/django-stubs
+git+https://github.com/typeddjango/django-stubs#egg=django-stubs[compatible-mypy]
 git+https://github.com/typeddjango/django-stubs#subdirectory=ext
 -e .[compatible-mypy,coreapi,markdown]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "mypy>=0.991",
     "django-stubs>=4.2.5",
     "typing-extensions>=3.10.0",
     "requests>=2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ dependencies = [
 
 # Keep compatible-mypy major.minor version pinned to what we use in CI (requirements.txt)
 extras_require = {
-    "compatible-mypy": ["mypy~=1.6.0"],
+    "compatible-mypy": ["mypy~=1.6.0", "django-stubs[compatible-mypy]"],
     "coreapi": ["coreapi>=2.0.0"],
     "markdown": ["types-Markdown>=0.1.5"],
 }


### PR DESCRIPTION
As [announced in 3.14.4 release notes](https://github.com/typeddjango/djangorestframework-stubs/releases/tag/3.14.4), we will drop the hard dependency on mypy. Users of djangorestframework-stubs with mypy will need to add their own dependency on mypy, or use `djangorestframework-stubs[compatible-mypy]` extra.

Currently mypy remains the only supported type checker. Improvements for other type checkers may be considered in the future, pull requests welcome.

## Related issues

* Related: https://github.com/typeddjango/django-stubs/pull/1782
* Related: https://github.com/typeddjango/django-stubs/issues/1628
