### PR TITLE
Tests: Allowlist stubtest cached_property error

### DIFF
--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -32,3 +32,6 @@ rest_framework.fields.TimeField.__init__
 rest_framework.serializers.DateField.__init__
 rest_framework.serializers.DateTimeField.__init__
 rest_framework.serializers.TimeField.__init__
+
+# Ignore @cached_property error "cannot reconcile @property on stub with runtime object"
+rest_framework.serializers.Serializer.fields


### PR DESCRIPTION
# I have made things!

Fixes stubtest in CI.

## Related issues

* Caused by https://github.com/typeddjango/django-stubs/pull/1771
