### PR TITLE
Replace `Manager` with `BaseManager`

### DIFF
--- a/rest_framework-stubs/generics.pyi
+++ b/rest_framework-stubs/generics.pyi
@@ -2,7 +2,8 @@ from _typeshed import Incomplete
 from collections.abc import Sequence
 from typing import Any, Protocol, TypeVar
 
-from django.db.models import Manager, Model
+from django.db.models import Model
+from django.db.models.manager import BaseManager
 from django.db.models.query import QuerySet
 from rest_framework import mixins, views
 from rest_framework.filters import BaseFilterBackend
@@ -15,7 +16,7 @@ _MT_co = TypeVar("_MT_co", bound=Model, covariant=True)
 _MT_inv = TypeVar("_MT_inv", bound=Model)
 
 def get_object_or_404(
-    queryset: type[_MT_co] | Manager[_MT_co] | QuerySet[_MT_co], *filter_args: Any, **filter_kwargs: Any
+    queryset: type[_MT_co] | BaseManager[_MT_co] | QuerySet[_MT_co], *filter_args: Any, **filter_kwargs: Any
 ) -> _MT_co: ...
 
 class UsesQuerySet(Protocol[_MT_co]):
@@ -31,7 +32,7 @@ class BaseFilterProtocol(Protocol[_MT_inv]):
     def get_schema_operation_parameters(self, view: views.APIView) -> Incomplete: ...
 
 class GenericAPIView(views.APIView, UsesQuerySet[_MT_co]):
-    queryset: QuerySet[_MT_co] | Manager[_MT_co] | None
+    queryset: QuerySet[_MT_co] | BaseManager[_MT_co] | None
     serializer_class: type[BaseSerializer] | None
     lookup_field: str
     lookup_url_kwarg: str | None

--- a/rest_framework-stubs/relations.pyi
+++ b/rest_framework-stubs/relations.pyi
@@ -1,7 +1,8 @@
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, Generic, TypeVar
 
-from django.db.models import Manager, Model, QuerySet
+from django.db.models import Model, QuerySet
+from django.db.models.manager import BaseManager
 from django_stubs_ext import StrOrPromise
 from rest_framework.fields import Field, Option
 from rest_framework.request import Request
@@ -32,7 +33,7 @@ _DT = TypeVar("_DT")  # Data Type
 _PT = TypeVar("_PT")  # Primitive Type
 
 class RelatedField(Generic[_MT, _DT, _PT], Field[_MT, _DT, _PT, Any]):
-    queryset: QuerySet[_MT] | Manager[_MT] | None
+    queryset: QuerySet[_MT] | BaseManager[_MT] | None
     html_cutoff: int | None
     html_cutoff_text: str | None
     def __init__(
@@ -40,7 +41,7 @@ class RelatedField(Generic[_MT, _DT, _PT], Field[_MT, _DT, _PT, Any]):
         *,
         many: bool = ...,
         allow_empty: bool = ...,
-        queryset: QuerySet[_MT] | Manager[_MT] | None = ...,
+        queryset: QuerySet[_MT] | BaseManager[_MT] | None = ...,
         html_cutoff: int | None = ...,
         html_cutoff_text: str = ...,
         read_only: bool = ...,
@@ -80,7 +81,7 @@ class PrimaryKeyRelatedField(RelatedField[_MT, _MT, Any]):
         *,
         many: bool = ...,
         allow_empty: bool = ...,
-        queryset: QuerySet[_MT] | Manager[_MT] | None = ...,
+        queryset: QuerySet[_MT] | BaseManager[_MT] | None = ...,
         html_cutoff: int | None = ...,
         html_cutoff_text: str = ...,
         read_only: bool = ...,
@@ -110,7 +111,7 @@ class HyperlinkedRelatedField(RelatedField[_MT, str, Hyperlink]):
         *,
         many: bool = ...,
         allow_empty: bool = ...,
-        queryset: QuerySet[_MT] | Manager[_MT] | None = ...,
+        queryset: QuerySet[_MT] | BaseManager[_MT] | None = ...,
         html_cutoff: int | None = ...,
         html_cutoff_text: str = ...,
         read_only: bool = ...,
@@ -142,7 +143,7 @@ class SlugRelatedField(RelatedField[_MT, str, str]):
         *,
         many: bool = ...,
         allow_empty: bool = ...,
-        queryset: QuerySet[_MT] | Manager[_MT] | None = ...,
+        queryset: QuerySet[_MT] | BaseManager[_MT] | None = ...,
         html_cutoff: int | None = ...,
         html_cutoff_text: str = ...,
         read_only: bool = ...,

--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -3,7 +3,8 @@ from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMappin
 from typing import Any, ClassVar, Generic, Literal, NoReturn, TypeVar
 
 from django.db import models
-from django.db.models import Manager, Model, QuerySet
+from django.db.models import Model, QuerySet
+from django.db.models.manager import BaseManager
 from django.utils.functional import cached_property
 from django_stubs_ext import StrOrPromise
 from rest_framework.exceptions import APIException as APIException
@@ -202,7 +203,7 @@ class ModelSerializer(Serializer, BaseSerializer[_MT]):
         extra_kwargs: dict[str, dict[str, Any]]
     def __init__(
         self,
-        instance: None | _MT | Sequence[_MT] | QuerySet[_MT] | Manager[_MT] = ...,
+        instance: None | _MT | Sequence[_MT] | QuerySet[_MT] | BaseManager[_MT] = ...,
         data: Any = ...,
         *,
         partial: bool = ...,


### PR DESCRIPTION
@flaeppe This is some example fallout from https://github.com/typeddjango/django-stubs/pull/1814 since `RelatedManager` base class was changed from `Manager` to `BaseManager`.

Without this change, I can no longer pass `RelatedManager`s to APIs that accept them.

I'm not entirely happy or sure about this. I think in pratice most managers, including `RelatedManager`s, do inherit from `Manager`.

`BaseManager` seems to be intended as an impementation detail in Django, not something users should be exposed to. But this will force users to replace `Manager` type hints with `BaseManager`, including my personal projects.

## Related issues

* https://github.com/typeddjango/django-stubs/pull/1814
