### PR TITLE
Allow `http.HTTPMethod` enum values in `@action()` decorator

### DIFF
--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -33,14 +33,14 @@ class MethodMapper(dict):
 _MIXED_CASE_HTTP_VERBS: TypeAlias = Sequence[
     # fmt: off
     Literal[
-        "get"    , "GET"    , HTTPMethod.GET    ,
-        "post"   , "POST"   , HTTPMethod.POST   ,
         "delete" , "DELETE" , HTTPMethod.DELETE ,
-        "put"    , "PUT"    , HTTPMethod.PUT    ,
-        "patch"  , "PATCH"  , HTTPMethod.PATCH  ,
-        "trace"  , "TRACE"  , HTTPMethod.TRACE  ,
+        "get"    , "GET"    , HTTPMethod.GET    ,
         "head"   , "HEAD"   , HTTPMethod.HEAD   ,
         "options", "OPTIONS", HTTPMethod.OPTIONS,
+        "patch"  , "PATCH"  , HTTPMethod.PATCH  ,
+        "post"   , "POST"   , HTTPMethod.POST   ,
+        "put"    , "PUT"    , HTTPMethod.PUT    ,
+        "trace"  , "TRACE"  , HTTPMethod.TRACE  ,
     ]
     # fmt: on
 ]

--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -17,6 +17,30 @@ from typing_extensions import Concatenate, ParamSpec, TypeAlias
 _View = TypeVar("_View", bound=Callable[..., HttpResponseBase])
 _P = ParamSpec("_P")
 _RESP = TypeVar("_RESP", bound=HttpResponseBase)
+_MixedCaseHttpMethod: TypeAlias = Literal[
+    "GET",
+    "POST",
+    "DELETE",
+    "PUT",
+    "PATCH",
+    "TRACE",
+    "HEAD",
+    "OPTIONS",
+    "get",
+    "post",
+    "delete",
+    "put",
+    "patch",
+    "trace",
+    "head",
+    "options",
+]
+if sys.version_info >= (3, 11):
+    from http import HTTPMethod
+
+    _HttpMethod: TypeAlias = _MixedCaseHttpMethod | HTTPMethod
+else:
+    _HttpMethod: TypeAlias = _MixedCaseHttpMethod
 
 class MethodMapper(dict):
     def __init__(self, action: _View, methods: Sequence[str]) -> None: ...
@@ -29,59 +53,6 @@ class MethodMapper(dict):
     def head(self, func: _View) -> _View: ...
     def options(self, func: _View) -> _View: ...
     def trace(self, func: _View) -> _View: ...
-
-if sys.version_info >= (3, 11):
-    from http import HTTPMethod
-
-    _MIXED_CASE_HTTP_VERBS: TypeAlias = Sequence[
-        Literal[
-            "GET",
-            "POST",
-            "DELETE",
-            "PUT",
-            "PATCH",
-            "TRACE",
-            "HEAD",
-            "OPTIONS",
-            "get",
-            "post",
-            "delete",
-            "put",
-            "patch",
-            "trace",
-            "head",
-            "options",
-            HTTPMethod.GET,
-            HTTPMethod.POST,
-            HTTPMethod.DELETE,
-            HTTPMethod.PUT,
-            HTTPMethod.PATCH,
-            HTTPMethod.TRACE,
-            HTTPMethod.HEAD,
-            HTTPMethod.OPTIONS,
-        ]
-    ]
-else:
-    _MIXED_CASE_HTTP_VERBS: TypeAlias = Sequence[
-        Literal[
-            "GET",
-            "POST",
-            "DELETE",
-            "PUT",
-            "PATCH",
-            "TRACE",
-            "HEAD",
-            "OPTIONS",
-            "get",
-            "post",
-            "delete",
-            "put",
-            "patch",
-            "trace",
-            "head",
-            "options",
-        ]
-    ]
 
 class ViewSetAction(Protocol[_View]):
     detail: bool
@@ -103,7 +74,7 @@ def throttle_classes(throttle_classes: Sequence[BaseThrottle | type[BaseThrottle
 def permission_classes(permission_classes: Sequence[_PermissionClass]) -> Callable[[_View], _View]: ...
 def schema(view_inspector: ViewInspector | type[ViewInspector] | None) -> Callable[[_View], _View]: ...
 def action(
-    methods: _MIXED_CASE_HTTP_VERBS | None = ...,
+    methods: Sequence[_HttpMethod] | None = ...,
     detail: bool = ...,
     url_path: str | None = ...,
     url_name: str | None = ...,

--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -14,13 +14,6 @@ from rest_framework.throttling import BaseThrottle
 from rest_framework.views import APIView, AsView  # noqa: F401
 from typing_extensions import Concatenate, ParamSpec, TypeAlias
 
-if sys.version_info >= (3, 11):
-    from http import HTTPMethod
-
-    PizzaBaseType = Literal["deep-pan", "thin"]
-else:
-    PizzaBaseType = str
-
 _View = TypeVar("_View", bound=Callable[..., HttpResponseBase])
 _P = ParamSpec("_P")
 _RESP = TypeVar("_RESP", bound=HttpResponseBase)

--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -85,7 +85,6 @@ else:
 
 class ViewSetAction(Protocol[_View]):
     detail: bool
-    methods: _MIXED_CASE_HTTP_VERBS
     url_path: str
     url_name: str
     kwargs: Mapping[str, Any]

--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -17,6 +17,7 @@ from typing_extensions import Concatenate, ParamSpec, TypeAlias
 _View = TypeVar("_View", bound=Callable[..., HttpResponseBase])
 _P = ParamSpec("_P")
 _RESP = TypeVar("_RESP", bound=HttpResponseBase)
+
 _MixedCaseHttpMethod: TypeAlias = Literal[
     "GET",
     "POST",

--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Mapping, Sequence
+from http import HTTPMethod
 from typing import Any, Literal, Protocol, TypeVar
 
 from django.http import HttpRequest
@@ -29,43 +30,24 @@ class MethodMapper(dict):
     def options(self, func: _View) -> _View: ...
     def trace(self, func: _View) -> _View: ...
 
-_LOWER_CASE_HTTP_VERBS: TypeAlias = Sequence[
-    Literal[
-        "get",
-        "post",
-        "delete",
-        "put",
-        "patch",
-        "trace",
-        "head",
-        "options",
-    ]
-]
-
 _MIXED_CASE_HTTP_VERBS: TypeAlias = Sequence[
+    # fmt: off
     Literal[
-        "GET",
-        "POST",
-        "DELETE",
-        "PUT",
-        "PATCH",
-        "TRACE",
-        "HEAD",
-        "OPTIONS",
-        "get",
-        "post",
-        "delete",
-        "put",
-        "patch",
-        "trace",
-        "head",
-        "options",
+        "get"    , "GET"    , HTTPMethod.GET    ,
+        "post"   , "POST"   , HTTPMethod.POST   ,
+        "delete" , "DELETE" , HTTPMethod.DELETE ,
+        "put"    , "PUT"    , HTTPMethod.PUT    ,
+        "patch"  , "PATCH"  , HTTPMethod.PATCH  ,
+        "trace"  , "TRACE"  , HTTPMethod.TRACE  ,
+        "head"   , "HEAD"   , HTTPMethod.HEAD   ,
+        "options", "OPTIONS", HTTPMethod.OPTIONS,
     ]
+    # fmt: on
 ]
 
 class ViewSetAction(Protocol[_View]):
     detail: bool
-    methods: _LOWER_CASE_HTTP_VERBS
+    methods: _MIXED_CASE_HTTP_VERBS
     url_path: str
     url_name: str
     kwargs: Mapping[str, Any]

--- a/rest_framework-stubs/decorators.pyi
+++ b/rest_framework-stubs/decorators.pyi
@@ -1,5 +1,5 @@
+import sys
 from collections.abc import Callable, Mapping, Sequence
-from http import HTTPMethod
 from typing import Any, Literal, Protocol, TypeVar
 
 from django.http import HttpRequest
@@ -13,6 +13,13 @@ from rest_framework.schemas.inspectors import ViewInspector
 from rest_framework.throttling import BaseThrottle
 from rest_framework.views import APIView, AsView  # noqa: F401
 from typing_extensions import Concatenate, ParamSpec, TypeAlias
+
+if sys.version_info >= (3, 11):
+    from http import HTTPMethod
+
+    PizzaBaseType = Literal["deep-pan", "thin"]
+else:
+    PizzaBaseType = str
 
 _View = TypeVar("_View", bound=Callable[..., HttpResponseBase])
 _P = ParamSpec("_P")
@@ -30,20 +37,58 @@ class MethodMapper(dict):
     def options(self, func: _View) -> _View: ...
     def trace(self, func: _View) -> _View: ...
 
-_MIXED_CASE_HTTP_VERBS: TypeAlias = Sequence[
-    # fmt: off
-    Literal[
-        "delete" , "DELETE" , HTTPMethod.DELETE ,
-        "get"    , "GET"    , HTTPMethod.GET    ,
-        "head"   , "HEAD"   , HTTPMethod.HEAD   ,
-        "options", "OPTIONS", HTTPMethod.OPTIONS,
-        "patch"  , "PATCH"  , HTTPMethod.PATCH  ,
-        "post"   , "POST"   , HTTPMethod.POST   ,
-        "put"    , "PUT"    , HTTPMethod.PUT    ,
-        "trace"  , "TRACE"  , HTTPMethod.TRACE  ,
+if sys.version_info >= (3, 11):
+    from http import HTTPMethod
+
+    _MIXED_CASE_HTTP_VERBS: TypeAlias = Sequence[
+        Literal[
+            "GET",
+            "POST",
+            "DELETE",
+            "PUT",
+            "PATCH",
+            "TRACE",
+            "HEAD",
+            "OPTIONS",
+            "get",
+            "post",
+            "delete",
+            "put",
+            "patch",
+            "trace",
+            "head",
+            "options",
+            HTTPMethod.GET,
+            HTTPMethod.POST,
+            HTTPMethod.DELETE,
+            HTTPMethod.PUT,
+            HTTPMethod.PATCH,
+            HTTPMethod.TRACE,
+            HTTPMethod.HEAD,
+            HTTPMethod.OPTIONS,
+        ]
     ]
-    # fmt: on
-]
+else:
+    _MIXED_CASE_HTTP_VERBS: TypeAlias = Sequence[
+        Literal[
+            "GET",
+            "POST",
+            "DELETE",
+            "PUT",
+            "PATCH",
+            "TRACE",
+            "HEAD",
+            "OPTIONS",
+            "get",
+            "post",
+            "delete",
+            "put",
+            "patch",
+            "trace",
+            "head",
+            "options",
+        ]
+    ]
 
 class ViewSetAction(Protocol[_View]):
     detail: bool

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -39,41 +39,37 @@
     main: |
         from rest_framework.permissions import BasePermission, IsAuthenticated
         from rest_framework.decorators import permission_classes
-
         class Permission(BasePermission):
             pass
-
         permission_classes([IsAuthenticated & Permission])
         permission_classes([IsAuthenticated | Permission])
         permission_classes([~Permission])
 
 - case: method_decorator
   main: |
-    import sys
-    from typing import Literal
-
     from rest_framework import viewsets
     from rest_framework.decorators import action
     from rest_framework.request import Request
     from rest_framework.response import Response
-
-    if sys.version_info >= (3, 11):
-        from http import HTTPMethod
-
-        enum_value: Literal[HTTPMethod.POST] = HTTPMethod.POST
-    else:
-        enum_value: Literal["POST"] = "POST"
-
     class MyView(viewsets.ViewSet):
-
       @action(methods=("get",), detail=False)
       def view_func_1(self, request: Request) -> Response: ...
-
       @action(methods=["post"], detail=False)
       def view_func_2(self, request: Request) -> Response: ...
-
       @action(methods=("GET",), detail=False)
       def view_func_3(self, request: Request) -> Response: ...
 
-      @action(methods=[enum_value], detail=False)
-      def view_func_4(self, request: Request) -> Response: ...
+- case: method_decorator_http_libary
+  skip: sys.version_info < (3, 11)
+  main: |
+    from http import HTTPMethod
+    from rest_framework import viewsets
+    from rest_framework.decorators import action
+    from rest_framework.request import Request
+    from rest_framework.response import Response
+    MY_VAR: HTTPMethod = HTTPMethod.POST
+    class MyView(viewsets.ViewSet):
+      @action(methods=[HTTPMethod.GET], detail=False)
+      def view_func_1(self, request: Request) -> Response: ...
+      @action(methods=[MY_VAR], detail=False)
+      def view_func_2(self, request: Request) -> Response: ...

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -49,6 +49,8 @@
 
 - case: method_decorator
   main: |
+    from http import HTTPMethod
+
     from rest_framework import viewsets
     from rest_framework.decorators import action
     from rest_framework.request import Request
@@ -59,5 +61,11 @@
       @action(methods=("get",), detail=False)
       def view_func_1(self, request: Request) -> Response: ...
 
-      @action(methods=["post",], detail=False)
+      @action(methods=["post"], detail=False)
       def view_func_2(self, request: Request) -> Response: ...
+
+      @action(methods=("GET",), detail=False)
+      def view_func_3(self, request: Request) -> Response: ...
+
+      @action(methods=[HTTPMethod.POST], detail=False)
+      def view_func_4(self, request: Request) -> Response: ...

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -39,8 +39,10 @@
     main: |
         from rest_framework.permissions import BasePermission, IsAuthenticated
         from rest_framework.decorators import permission_classes
+
         class Permission(BasePermission):
             pass
+
         permission_classes([IsAuthenticated & Permission])
         permission_classes([IsAuthenticated | Permission])
         permission_classes([~Permission])
@@ -51,6 +53,7 @@
     from rest_framework.decorators import action
     from rest_framework.request import Request
     from rest_framework.response import Response
+
     class MyView(viewsets.ViewSet):
       @action(methods=("get",), detail=False)
       def view_func_1(self, request: Request) -> Response: ...
@@ -67,6 +70,7 @@
     from rest_framework.decorators import action
     from rest_framework.request import Request
     from rest_framework.response import Response
+
     MY_VAR: HTTPMethod = HTTPMethod.POST
     class MyView(viewsets.ViewSet):
       @action(methods=[HTTPMethod.GET], detail=False)

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -49,12 +49,20 @@
 
 - case: method_decorator
   main: |
-    from http import HTTPMethod
+    import sys
+    from typing import Literal
 
     from rest_framework import viewsets
     from rest_framework.decorators import action
     from rest_framework.request import Request
     from rest_framework.response import Response
+
+    if sys.version_info >= (3, 11):
+        from http import HTTPMethod
+
+        enum_value: Literal[HTTPMethod.POST] = HTTPMethod.POST
+    else:
+        enum_value: Literal["POST"] = "POST"
 
     class MyView(viewsets.ViewSet):
 
@@ -67,5 +75,5 @@
       @action(methods=("GET",), detail=False)
       def view_func_3(self, request: Request) -> Response: ...
 
-      @action(methods=[HTTPMethod.POST], detail=False)
+      @action(methods=[enum_value], detail=False)
       def view_func_4(self, request: Request) -> Response: ...


### PR DESCRIPTION
# I have made things!

Added possibility to specify `http.HTTPMethod` enum as an action's method

## Related issues

Fixes: https://github.com/typeddjango/djangorestframework-stubs/issues/396

**Notes for reviewer:**
- as this feature is added only on Python 3.11 I tried to do special treatment (check againt `sys.version_Info`, just do not know if I did it right, especially in the tests. It would actually more proper to mark test as Python3.11+ only and add in that test only the line with `HTTPMethod` and on previous versions this test will be just skipped. But I do not know how to do it.
- I have deleted the `Sequence` for lowercase as an options for `action` specification, apparently there is no test for it. I even do not know if it is correct, will double check later if `UPPERCASE` and `HTTPMethod` can be specified there. I just do not know why they are different.
- added 2 extra tests, one for `UPPERCASE` as it was not tested and one for `HTTPMethod`

Please feel free to comment and I will make appropriate changes. @intgr 🎉 
