### PR TITLE
Version 3.14.5 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("README.md") as f:
     readme = f.read()
 
 dependencies = [
-    "django-stubs>=4.2.5",
+    "django-stubs>=4.2.7",
     "typing-extensions>=3.10.0",
     "requests>=2.0.0",
     "types-requests>=0.1.12",
@@ -36,7 +36,7 @@ extras_require = {
 
 setup(
     name="djangorestframework-stubs",
-    version="3.14.4",
+    version="3.14.5",
     description="PEP-484 stubs for django-rest-framework",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Draft release notes: https://github.com/typeddjango/djangorestframework-stubs/releases/edit/untagged-8c34d4cc703275edb47d

## Related issues

* https://github.com/typeddjango/django-stubs/issues/1828
* https://github.com/typeddjango/django-stubs/pull/1856