### PR TITLE
CI: Run tests daily to detect incompatible django-stubs changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+  schedule:
+    # 15:41 UTC every day
+    - cron: "41 15 * * TUE"
 
 jobs:
   mypy-self-check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
   schedule:
     # 15:41 UTC every day
-    - cron: "41 15 * * TUE"
+    - cron: "41 15 * * *"
 
 jobs:
   mypy-self-check:


### PR DESCRIPTION
# I have made things!

Motivated by examples like #518, #508 and many others. It happens every few weeks that a change in `django-stubs` also requires followup changes in `djangorestframework-stubs`.

Currently, I only find out when someone opens a PR against DRF-stubs and then CI fails. Having scheduled CI would help me be more proactive about these.

Alternatively, we could also change `django-stubs` CI to automatically trigger `workflow_dispatch` in DRF-stubs repo on every merge to master. But that would have more moving parts. I think daily schedule is good enough for the time being.
