### PR TITLE
Fix class hierachy and TypeVars of Serializer classes

### DIFF
--- a/rest_framework-stubs/relations.pyi
+++ b/rest_framework-stubs/relations.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 
 from django.db.models import Manager, Model, QuerySet
 from django_stubs_ext import StrOrPromise
@@ -31,7 +31,7 @@ _MT = TypeVar("_MT", bound=Model)
 _DT = TypeVar("_DT")  # Data Type
 _PT = TypeVar("_PT")  # Primitive Type
 
-class RelatedField(Generic[_MT, _DT, _PT], Field[_MT, _DT, _PT, Any]):
+class RelatedField(Field[_MT, _DT, _PT, Any]):
     queryset: QuerySet[_MT] | Manager[_MT] | None
     html_cutoff: int | None
     html_cutoff_text: str | None

--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
-from typing import Any, ClassVar, Generic, Literal, NoReturn, TypeVar
+from typing import Any, ClassVar, Literal, NoReturn, TypeVar
 
 from django.db import models
 from django.db.models import Manager, Model, QuerySet
@@ -73,7 +73,7 @@ ALL_FIELDS: str
 _MT = TypeVar("_MT", bound=Model)  # Model Type
 _IN = TypeVar("_IN")  # Instance Type
 
-class BaseSerializer(Generic[_IN], Field[Any, Any, Any, _IN]):
+class BaseSerializer(Field[Any, Any, Any, _IN]):
     partial: bool
     many: bool
     instance: _IN | None
@@ -124,10 +124,7 @@ class SerializerMetaclass(type):
 
 def as_serializer_error(exc: Exception) -> dict[str, list[ErrorDetail]]: ...
 
-class Serializer(
-    BaseSerializer[_IN],
-    metaclass=SerializerMetaclass,
-):
+class Serializer(BaseSerializer[_IN], metaclass=SerializerMetaclass):
     _declared_fields: dict[str, Field]
     default_error_messages: ClassVar[dict[str, StrOrPromise]]
     def get_initial(self) -> Any: ...
@@ -190,14 +187,14 @@ class ListSerializer(
 
 def raise_errors_on_nested_writes(method_name: str, serializer: BaseSerializer, validated_data: Any) -> None: ...
 
-class ModelSerializer(Serializer, BaseSerializer[_MT]):
+class ModelSerializer(Serializer[_MT]):
     serializer_field_mapping: dict[type[models.Field], type[Field]]
     serializer_related_field: type[RelatedField]
     serializer_related_to_field: type[RelatedField]
     serializer_url_field: type[RelatedField]
     serializer_choice_field: type[Field]
     url_field_name: str | None
-    instance: _MT | Sequence[_MT] | None
+    instance: _MT | Sequence[_MT] | None  # type: ignore[assignment]
 
     class Meta:
         model: type[_MT]  # type: ignore

--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -146,9 +146,7 @@ class Serializer(BaseSerializer[_IN], metaclass=SerializerMetaclass):
     @property
     def errors(self) -> ReturnDict: ...
 
-class ListSerializer(
-    BaseSerializer[_IN],
-):
+class ListSerializer(BaseSerializer[_IN]):
     child: Field | BaseSerializer | None
     many: bool
     default_error_messages: ClassVar[dict[str, StrOrPromise]]


### PR DESCRIPTION
# I have made thunks!

* `ModelSerializer` was incorrectly deriving from `Serializer[Any]` and `BaseSerializer[T]`; replaced with `Serializer[T]`.
  This brings it into sync with DRF upstream.
* Added TypeVar to `HyperlinkedModelSerializer` class.
* Removed unnecessary `Generic[]` where implicit TypeVars are sufficient.

  https://mypy.readthedocs.io/en/stable/generics.html#defining-subclasses-of-generic-classes

  > If there are no Generic[...] in bases, then all type variables are collected in the lexicographic order (i.e. by first appearance).
