### PR TITLE
Use `Pattern[str]` for `RegexField`

### DIFF
--- a/rest_framework-stubs/fields.pyi
+++ b/rest_framework-stubs/fields.pyi
@@ -181,7 +181,7 @@ class EmailField(CharField): ...
 class RegexField(CharField):
     def __init__(
         self,
-        regex: str | Pattern,
+        regex: str | Pattern[str],
         *,
         read_only: bool = ...,
         write_only: bool = ...,


### PR DESCRIPTION
The underlying django validators requires `Pattern[str]`