### PR TITLE
allow floats for _GetDataType

### DIFF
--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -18,8 +18,8 @@ from rest_framework.response import _MonkeyPatchedResponse
 from typing_extensions import TypeAlias
 
 _GetDataType: TypeAlias = (
-    Mapping[str, str | bytes | int | Iterable[str | bytes | int]]
-    | Iterable[tuple[str, str | bytes | int | Iterable[str | bytes | int]]]
+    Mapping[str, str | bytes | float | Iterable[str | bytes | float]]
+    | Iterable[tuple[str, str | bytes | float | Iterable[str | bytes | float]]]
     | None
 )
 


### PR DESCRIPTION
note that `float` in the mypy typing system includes `int` so including `| int` would be redundant
