### PR TITLE
[3.15] Add `represent_timedelta`, a function related to `CustomScalar`

### DIFF
--- a/rest_framework-stubs/utils/encoders.pyi
+++ b/rest_framework-stubs/utils/encoders.pyi
@@ -1,3 +1,10 @@
+import datetime
 import json
 
+from yaml import Dumper, ScalarNode
+
 class JSONEncoder(json.JSONEncoder): ...
+
+class CustomScalar:
+    @classmethod
+    def represent_timedelta(cls, dumper: Dumper, data: datetime.timedelta) -> ScalarNode: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -147,5 +147,4 @@ rest_framework.serializers.Field.__class_getitem__
 rest_framework.serializers.ListSerializer.run_child_validation
 rest_framework.serializers.ModelSerializer.get_unique_together_constraints
 rest_framework.templatetags.rest_framework.optional_logout
-rest_framework.utils.encoders.CustomScalar
 rest_framework.utils.field_mapping.get_unique_validators


### PR DESCRIPTION
# I have made things!
I added `represent_timedelta`, a function related to `CustomScalar` in DRF version 3.15.

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Upstream PR: https://github.com/encode/django-rest-framework/pull/9007
