### PR TITLE
Fix CI: suppress mypy errors in test suite that come from 3rd party packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,8 @@ jobs:
           SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 
       - name: Run tests
-        run: pytest
+        # Suppress errors from other packages due to https://github.com/typeddjango/pytest-mypy-plugins/issues/134
+        run: pytest --mypy-only-local-stub
 
   stubtest:
     timeout-minutes: 10

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,23 +23,3 @@ plugins =
 
 [mypy.plugins.django-stubs]
 django_settings_module = scripts.drf_tests_settings
-
-# Suppress errors from site-packages due to https://github.com/typeddjango/pytest-mypy-plugins/issues/134
-[mypy-uritemplate.*]
-warn_unreachable = false
-
-[mypy-yaml.*]
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-
-[mypy-urllib3.*]
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-
-[mypy-requests.*]
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-
-[mypy-markdown.*]
-disallow_untyped_defs = false
-disallow_incomplete_defs = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ djangorestframework==3.15.1
 types-pytz==2024.1.0.20240417
 types-requests==2.31.0.20240406
 types-urllib3==1.26.25.14
+psycopg2-binary
 django-stubs[compatible-mypy] @ git+https://github.com/typeddjango/django-stubs
 django-stubs-ext @ git+https://github.com/typeddjango/django-stubs#subdirectory=ext
 -e .[compatible-mypy,coreapi,markdown]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ djangorestframework==3.15.1
 types-pytz==2024.1.0.20240417
 types-requests==2.31.0.20240406
 types-urllib3==1.26.25.14
-psycopg2-binary
 django-stubs[compatible-mypy] @ git+https://github.com/typeddjango/django-stubs
 django-stubs-ext @ git+https://github.com/typeddjango/django-stubs#subdirectory=ext
 -e .[compatible-mypy,coreapi,markdown]


### PR DESCRIPTION
`djangorestframework-stubs` CI was failing due to changes in `django-stubs` upstream.

This issue has bit us a few times in the past too. A suggestion was proposed in https://github.com/typeddjango/pytest-mypy-plugins/issues/134#issuecomment-1817723015 that should fix this once and for all, and we can remove hacks that I previously added in `mypy.ini`.
