### PR TITLE
[3.15.1] Update `rest_framework.compat`

### DIFF
--- a/rest_framework-stubs/compat.pyi
+++ b/rest_framework-stubs/compat.pyi
@@ -24,6 +24,10 @@ try:
 except ImportError:
     yaml: TypeAlias = None  # type: ignore[no-redef]
 try:
+    import inflection
+except ImportError:
+    inflection: TypeAlias = None  # type: ignore[no-redef]
+try:
     import requests
 except ImportError:
     requests: TypeAlias = None  # type: ignore[no-redef]
@@ -63,6 +67,7 @@ __all__ = [
     "QuerySet",
     "uritemplate",
     "yaml",
+    "inflection",
     "pygments",
     "markdown",
     "apply_markdown",


### PR DESCRIPTION
# I have made things!
I updated  `rest_framework.compat.inflection` in DRF version 3.15.1

[rest framework 3.15.1 release](https://github.com/encode/django-rest-framework/releases/tag/3.15.1)
<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
Upstream PR
- https://github.com/encode/django-rest-framework/pull/9303
