### PR TITLE
Improve `DefaultRouter` constructor and attributes

### DIFF
--- a/rest_framework-stubs/routers.pyi
+++ b/rest_framework-stubs/routers.pyi
@@ -60,10 +60,16 @@ class DefaultRouter(SimpleRouter):
     include_format_suffixes: bool
     root_view_name: str
     default_schema_renderers: Any
-    APIRootView = APIRootView
-    APISchemaView = SchemaView
-    SchemaGenerator = SchemaGenerator
-
+    APIRootView: type[APIRootView]
+    APISchemaView: type[SchemaView]
+    SchemaGenerator: type[SchemaGenerator]
     root_renderers: list[type[BaseRenderer]]
-    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def __init__(
+        self,
+        trailing_slash: bool = True,
+        use_regex_path: bool = True,
+        *,
+        root_renderers: list[type[BaseRenderer]] = ...,
+    ) -> None: ...
     def get_api_root_view(self, api_urls: Any | None = ...) -> Callable: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -65,9 +65,6 @@ rest_framework.request.Request.QUERY_PARAMS
 rest_framework.routers.BaseRouter
 rest_framework.routers.BaseRouter.register
 rest_framework.routers.DefaultRouter
-rest_framework.routers.DefaultRouter.APIRootView
-rest_framework.routers.DefaultRouter.APISchemaView
-rest_framework.routers.DefaultRouter.SchemaGenerator
 rest_framework.routers.RenameRouterMethods
 rest_framework.routers.SimpleRouter
 rest_framework.schemas.SchemaGenerator.__init__


### PR DESCRIPTION
Noticed this while working on drf-nested-routers (https://github.com/alanjds/drf-nested-routers/pull/345)