### PR TITLE
Mypy: Don't ignore missing imports (remove `ignore_missing_imports`)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,6 @@
 [mypy]
 allow_redefinition = true
 check_untyped_defs = true
-ignore_missing_imports = true
 incremental = true
 strict_optional = true
 show_traceback = true
@@ -11,7 +10,7 @@ warn_unused_configs = true
 warn_unreachable = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-disable_error_code = empty-body
+disable_error_code = empty-body,import-untyped
 # TODO: update our test error messages to match new mypy output
 show_error_codes = false
 force_uppercase_builtins = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,7 +10,7 @@ warn_unused_configs = true
 warn_unreachable = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-disable_error_code = empty-body,import-untyped
+disable_error_code = empty-body
 # TODO: update our test error messages to match new mypy output
 show_error_codes = false
 force_uppercase_builtins = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ djangorestframework==3.15.1
 types-pytz==2024.1.0.20240417
 types-requests==2.31.0.20240406
 types-urllib3==1.26.25.14
+types-Pygments==2.18.0.20240506
 django-stubs[compatible-mypy] @ git+https://github.com/typeddjango/django-stubs
 django-stubs-ext @ git+https://github.com/typeddjango/django-stubs#subdirectory=ext
 -e .[compatible-mypy,coreapi,markdown]

--- a/rest_framework-stubs/compat.pyi
+++ b/rest_framework-stubs/compat.pyi
@@ -8,7 +8,7 @@ try:
 except ImportError:
     postgres_fields: TypeAlias = None  # type: ignore[no-redef]
 try:
-    import coreapi
+    import coreapi  # type: ignore[import-untyped]
 except ImportError:
     coreapi: TypeAlias = None  # type: ignore[no-redef]
 try:
@@ -16,7 +16,7 @@ try:
 except ImportError:
     uritemplate: TypeAlias = None  # type: ignore[no-redef]
 try:
-    import coreschema
+    import coreschema  # type: ignore[import-untyped]
 except ImportError:
     coreschema: TypeAlias = None  # type: ignore[no-redef]
 try:

--- a/rest_framework-stubs/compat.pyi
+++ b/rest_framework-stubs/compat.pyi
@@ -24,7 +24,7 @@ try:
 except ImportError:
     yaml: TypeAlias = None  # type: ignore[no-redef]
 try:
-    import inflection
+    import inflection  # type: ignore[import-not-found,unused-ignore]
 except ImportError:
     inflection: TypeAlias = None  # type: ignore[no-redef]
 try:

--- a/rest_framework-stubs/pagination.pyi
+++ b/rest_framework-stubs/pagination.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Sequence
 from typing import Any, NamedTuple, TypeVar
 
-from coreapi import Field as CoreAPIField
+from coreapi import Field as CoreAPIField  # type: ignore[import-untyped]
 from django.core.paginator import Page, Paginator
 from django.db.models import Model, QuerySet
 from rest_framework.request import Request

--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -2,7 +2,7 @@ from _typeshed import Incomplete
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-import coreapi
+import coreapi  # type: ignore[import-untyped]
 import requests
 import urllib3
 from django.contrib.auth.base_user import AbstractBaseUser


### PR DESCRIPTION
Fortunately this was not hiding any genuine bugs in DRF-stubs.

## Related issues

* https://github.com/typeddjango/django-stubs/pull/2058
