### PR TITLE
Add type hints to JSON utility methods in `rest_framework.utils`

### DIFF
--- a/rest_framework-stubs/utils/json.pyi
+++ b/rest_framework-stubs/utils/json.pyi
@@ -1,7 +1,55 @@
-from typing import Any, NoReturn
+from json import JSONDecoder, JSONEncoder
+from typing import IO, Any, Callable, NoReturn
 
 def strict_constant(o: Any) -> NoReturn: ...
-def dump(*args: Any, **kwargs: Any) -> None: ...
-def dumps(*args: Any, **kwargs: Any) -> str: ...
-def load(*args: Any, **kwargs: Any) -> Any: ...
-def loads(*args: Any, **kwargs: Any) -> Any: ...
+def dump(
+    obj: Any,
+    fp: IO[str],
+    *,
+    skipkeys: bool = False,
+    ensure_ascii: bool = True,
+    check_circular: bool = True,
+    allow_nan: bool = True,
+    cls: type[JSONEncoder] | None = None,
+    indent: int | str | None = None,
+    separators: tuple[str, str] | None = None,
+    default: Callable[[Any], Any] | None = None,
+    sort_keys: bool = False,
+    **kw: Any,
+) -> None: ...
+def dumps(
+    obj: Any,
+    *,
+    skipkeys: bool = False,
+    ensure_ascii: bool = True,
+    check_circular: bool = True,
+    allow_nan: bool = True,
+    cls: type[JSONEncoder] | None = None,
+    indent: int | str | None = None,
+    separators: tuple[str, str] | None = None,
+    default: Callable[[Any], Any] | None = None,
+    sort_keys: bool = False,
+    **kw: Any,
+) -> str: ...
+def load(
+    fp: IO[str],
+    *,
+    cls: type[JSONDecoder] | None = None,
+    object_hook: Callable[[dict[str, Any]], Any] | None = None,
+    parse_float: Callable[[str], Any] | None = None,
+    parse_int: Callable[[str], Any] | None = None,
+    parse_constant: Callable[[str], Any] | None = None,
+    object_pairs_hook: Callable[[list[tuple[str, Any]]], Any] | None = None,
+    **kw: Any,
+) -> Any: ...
+def loads(
+    s: str,
+    *,
+    cls: type[JSONDecoder] | None = None,
+    object_hook: Callable[[dict[str, Any]], Any] | None = None,
+    parse_float: Callable[[str], Any] | None = None,
+    parse_int: Callable[[str], Any] | None = None,
+    parse_constant: Callable[[str], Any] | None = None,
+    object_pairs_hook: Callable[[list[tuple[str, Any]]], Any] | None = None,
+    **kw: Any,
+) -> Any: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -112,10 +112,6 @@ rest_framework.test.APIRequestFactory.put
 rest_framework.test.RequestsClient.__init__
 rest_framework.throttling.SimpleRateThrottle.cache
 rest_framework.utils.encoders.JSONEncoder.default
-rest_framework.utils.json.dump
-rest_framework.utils.json.dumps
-rest_framework.utils.json.load
-rest_framework.utils.json.loads
 rest_framework.validators.BaseUniqueForValidator.message
 rest_framework.validators.ContextValidator
 rest_framework.validators.Validator


### PR DESCRIPTION
# I have made things!

This pull request adds type hints to the JSON utility methods in the `rest_framework.utils.json` module. The changes include specifying the types for `dump`, `dumps`, `load`, and `loads` methods. This enhancement improves code readability and provides better support for static type checkers.