### PR TITLE
Fix `APIRequestFactory` method signatures

### DIFF
--- a/rest_framework-stubs/test.pyi
+++ b/rest_framework-stubs/test.pyi
@@ -59,12 +59,12 @@ class APIRequestFactory(DjangoRequestFactory):
     renderer_classes: Any
     def __init__(self, enforce_csrf_checks: bool = ..., **defaults: Any) -> None: ...
     def request(self, **kwargs: Any) -> Request: ...  # type: ignore[override]
-    def get(self, path: str, data: _GetDataType = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
-    def post(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
-    def put(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
-    def patch(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
-    def delete(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
-    def options(self, path: str, data: dict[str, str] | str = ..., format: str | None = ..., content_type: Any | None = ..., follow: bool = ..., **extra: Any) -> Request: ...  # type: ignore[override]
+    def get(self, path: str, data: _GetDataType = ..., **extra: Any) -> Request: ...  # type: ignore[override]
+    def post(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., **extra: Any) -> Request: ...  # type: ignore[override]
+    def put(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., **extra: Any) -> Request: ...  # type: ignore[override]
+    def patch(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., **extra: Any) -> Request: ...  # type: ignore[override]
+    def delete(self, path: str, data: Any | None = ..., format: str | None = ..., content_type: str | None = ..., **extra: Any) -> Request: ...  # type: ignore[override]
+    def options(self, path: str, data: dict[str, str] | str | None = ..., format: str | None = ..., content_type: Any | None = ..., **extra: Any) -> Request: ...  # type: ignore[override]
     def generic(  # type: ignore[override]
         self, method: str, path: str, data: str = ..., content_type: str = ..., secure: bool = ..., **extra: Any
     ) -> Request: ...

--- a/scripts/stubtest/allowlist_todo.txt
+++ b/scripts/stubtest/allowlist_todo.txt
@@ -103,12 +103,6 @@ rest_framework.settings.DefaultsSettings
 rest_framework.settings.api_settings
 rest_framework.templatetags.rest_framework.urlize_quoted_links
 rest_framework.test.APIClient.options
-rest_framework.test.APIRequestFactory.delete
-rest_framework.test.APIRequestFactory.get
-rest_framework.test.APIRequestFactory.options
-rest_framework.test.APIRequestFactory.patch
-rest_framework.test.APIRequestFactory.post
-rest_framework.test.APIRequestFactory.put
 rest_framework.test.RequestsClient.__init__
 rest_framework.throttling.SimpleRateThrottle.cache
 rest_framework.utils.encoders.JSONEncoder.default


### PR DESCRIPTION
# I have made things!

I have updated the method signatures in `APIRequestFactory` to include the correct types and removed unnecessary variables.

- Removed the `follow: bool = ...` parameter from all methods.
- Updated the `options` method to accept `data: dict[str, str] | str | None`.