### PR TITLE
Add `objects` attribute to `Token`

### DIFF
--- a/rest_framework-stubs/authtoken/models.pyi
+++ b/rest_framework-stubs/authtoken/models.pyi
@@ -1,12 +1,14 @@
-from typing import Any
+from typing import Any, ClassVar
 
 from django.db import models
+from django.db.models.manager import Manager
 from typing_extensions import Self
 
 class Token(models.Model):
     key: models.CharField
     user: models.OneToOneField
     created: models.DateTimeField
+    objects: ClassVar[Manager[Self]]
     @classmethod
     def generate_key(cls) -> str: ...
 


### PR DESCRIPTION
Yes, I remember now that adding explicit `objects` helps with `pyright`