### PR TITLE
Set configured user model as `request.user`

### DIFF
--- a/rest_framework-stubs/request.pyi
+++ b/rest_framework-stubs/request.pyi
@@ -4,7 +4,7 @@ from contextlib import AbstractContextManager, contextmanager
 from types import TracebackType
 from typing import Any
 
-from django.contrib.auth.base_user import AbstractBaseUser
+from django.contrib.auth.base_user import AbstractBaseUser, _UserModel
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from django.http.request import _ImmutableQueryDict
@@ -69,9 +69,9 @@ class Request(HttpRequest):
     @property
     def data(self) -> dict[str, Any]: ...
     @property
-    def user(self) -> AbstractBaseUser | AnonymousUser: ...
+    def user(self) -> _UserModel | AnonymousUser: ...
     @user.setter
-    def user(self, value: AbstractBaseUser | AnonymousUser) -> None: ...
+    def user(self, value: _UserModel | AnonymousUser) -> None: ...
     @property
     def auth(self) -> Token | Any: ...
     @auth.setter

--- a/scripts/stubtest/allowlist.txt
+++ b/scripts/stubtest/allowlist.txt
@@ -32,3 +32,7 @@ rest_framework.serializers.TimeField.__init__
 
 # Ignore @cached_property error "cannot reconcile @property on stub with runtime object"
 rest_framework.serializers.Serializer.fields
+
+# Generated objects:
+rest_framework.authtoken.models.Token@AnnotatedWith
+rest_framework.authtoken.models.TokenProxy@AnnotatedWith


### PR DESCRIPTION
Uses the placeholder `_UserModel` from `django-stubs` to hook in to its plugin to get the configured model.

## Related issues

- Closes #650 