### PR TITLE
Document the release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,15 +111,15 @@ The workflow for contributions is fairly simple:
    - Update `django-stubs>=` dependency to point to latest `django-stubs` release.
    - Use pull request title "Version x.y.z release" by convention.
 
-2. Ensure the CI succeeds. A maintainer must merge this PR. If it's just a verison bump, no need to wait
-   for a second maintainer's approval.
+2. Ensure the CI succeeds. A maintainer must merge this PR. If it's just a verison bump, no need
+   to wait for a second maintainer's approval.
 
-3. [Create a new GitHub release](https://github.com/typeddjango/djangorestframework-stubs/releases/new)
+3. [Create a new GitHub release](https://github.com/typeddjango/djangorestframework-stubs/releases/new):
 
    - Under "Choose a tag" enter the new version number. Do NOT use `v` prefix.
    - Click "Generate release notes".
-   - Delete all release notes lines containing `by @pre-commit-ci` or `by @dependabot`, as these are
-     irrelevant for our users.
+   - Delete all release notes lines containing `by @pre-commit-ci` or `by @dependabot`, as these
+     are irrelevant for our users.
 
 4. Once you feel brave enough, click "Publish release".
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ The workflow for contributions is fairly simple:
 
 ## Releasing `djangorestframework-stubs`
 
-1. Open a pull request that updates `setup.py` (anyone can open this PR, not just maintainers)
+1. Open a pull request that updates `setup.py` (anyone can open this PR, not just maintainers):
 
    - Increase `version=` value within `setup(...)`. Version number `major.minor.patch` is formed as follows:
 
@@ -109,7 +109,7 @@ The workflow for contributions is fairly simple:
      `patch` is sequentially increasing for each stubs release. Reset to `0` if `major.minor` was updated.
 
    - Update `django-stubs>=` dependency to point to latest `django-stubs` release.
-   - Use PR title "Version x.y.z release" by convention
+   - Use pull request title "Version x.y.z release" by convention.
 
 2. Ensure the CI succeeds. A maintainer must merge this PR. If it's just a verison bump, no need to wait
    for a second maintainer's approval.
@@ -123,4 +123,4 @@ The workflow for contributions is fairly simple:
 
 4. Once you feel brave enough, click "Publish release".
 
-5. Check that the [release pipeline](https://github.com/typeddjango/djangorestframework-stubs/actions/workflows/release.yml) succeeds.
+5. Check that the [release workflow](https://github.com/typeddjango/djangorestframework-stubs/actions/workflows/release.yml) succeeds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,3 +96,31 @@ The workflow for contributions is fairly simple:
 3. make whatever changes you want to contribute.
 4. ensure your contribution does not introduce linting issues or breaks the tests by linting and testing the code.
 5. make a pull request with an adequate description.
+
+
+## Releasing `djangorestframework-stubs`
+
+1. Open a pull request that updates `setup.py` (anyone can open this PR, not just maintainers)
+
+   - Increase `version=` value within `setup(...)`. Version number `major.minor.patch` is formed as follows:
+
+     `major.minor` version must match newest supported `djangorestframework` release.
+
+     `patch` is sequentially increasing for each stubs release. Reset to `0` if `major.minor` was updated.
+
+   - Update `django-stubs>=` dependency to point to latest `django-stubs` release.
+   - Use PR title "Version x.y.z release" by convention
+
+2. Ensure the CI succeeds. A maintainer must merge this PR. If it's just a verison bump, no need to wait
+   for a second maintainer's approval.
+
+3. [Create a new GitHub release](https://github.com/typeddjango/djangorestframework-stubs/releases/new)
+
+   - Under "Choose a tag" enter the new version number. Do NOT use `v` prefix.
+   - Click "Generate release notes".
+   - Delete all release notes lines containing `by @pre-commit-ci` or `by @dependabot`, as these are
+     irrelevant for our users.
+
+4. Once you feel brave enough, click "Publish release".
+
+5. Check that the [release pipeline](https://github.com/typeddjango/djangorestframework-stubs/actions/workflows/release.yml) succeeds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ The workflow for contributions is fairly simple:
 2. Ensure the CI succeeds. A maintainer must merge this PR. If it's just a verison bump, no need
    to wait for a second maintainer's approval.
 
-3. [Create a new GitHub release](https://github.com/typeddjango/djangorestframework-stubs/releases/new):
+3. Maintainers need to [сreate a new GitHub release](https://github.com/typeddjango/djangorestframework-stubs/releases/new):
 
    - Under "Choose a tag" enter the new version number. Do NOT use `v` prefix.
    - Click "Generate release notes".


### PR DESCRIPTION
This is my vision of what the release process looks like after release automation (#660) is merged.

Once we reach agreement here, I will also open a similar PR for `django-stubs`.

[See rendered Markdown here](https://github.com/intgr/djangorestframework-stubs/blob/document-releases/CONTRIBUTING.md#releasing-djangorestframework-stubs).

## Related issues

* #660
