### PR TITLE
Improve `GenericAPIView.serializer_class` classvar type generics

### DIFF
--- a/rest_framework-stubs/generics.pyi
+++ b/rest_framework-stubs/generics.pyi
@@ -33,7 +33,7 @@ class BaseFilterProtocol(Protocol[_MT_inv]):
 
 class GenericAPIView(views.APIView, UsesQuerySet[_MT_co]):
     queryset: QuerySet[_MT_co] | Manager[_MT_co] | None
-    serializer_class: type[BaseSerializer] | None
+    serializer_class: type[BaseSerializer[_MT_co]] | None
     lookup_field: str
     lookup_url_kwarg: str | None
     filter_backends: Sequence[type[BaseFilterBackend | BaseFilterProtocol[_MT_co]]]


### PR DESCRIPTION
# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

The type for the attribute does not match what the `get_serializer_class` function returns.

Thus, modifying it to match so that the truthy type of it is `type[BaseSerializer[_MT_co]]`

Unfortunately this doesn't solve the issue of projects programmatically returning different serializers in `get_serializer_class` such that one option would be: `return self.serializer_class` such that it would be technically incompatible with the typing. But that seems outside the scope of this change and there are other ways to accomplish it (e.g. holding known serializer classes in a `dict` on the class as an attribute).

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->
- Closes #673 
<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
