### PR TITLE
use Sequence for default_validators

### DIFF
--- a/rest_framework-stubs/fields.pyi
+++ b/rest_framework-stubs/fields.pyi
@@ -73,7 +73,7 @@ class Field(Generic[_VT, _DT, _RP, _IN]):
     default: _VT | None
     default_empty_html: Any
     default_error_messages: ClassVar[dict[str, StrOrPromise]]
-    default_validators: list[Validator[_VT]]
+    default_validators: Sequence[Validator[_VT]]
     error_messages: dict[str, StrOrPromise]
     field_name: str | None
     help_text: StrOrPromise | None


### PR DESCRIPTION
while the literal in code is an empty list, it is only used as an iterable (in `get_validators`)

relaxing to sequence makes it easier to use a list literal in subclasses which have a homogeneous list (without needing an explicit annotation)
