### PR TITLE
[Breaking change] Remove work-around for `ModelSerializer.instance` field for `many=True`

### DIFF
--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -192,7 +192,7 @@ class ModelSerializer(Serializer[_MT]):
     serializer_url_field: type[RelatedField]
     serializer_choice_field: type[Field]
     url_field_name: str | None
-    instance: _MT | None  # type: ignore[assignment]
+    instance: _MT | None
 
     class Meta:
         model: type[_MT]  # type: ignore

--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -192,7 +192,7 @@ class ModelSerializer(Serializer[_MT]):
     serializer_url_field: type[RelatedField]
     serializer_choice_field: type[Field]
     url_field_name: str | None
-    instance: _MT | Sequence[_MT] | None  # type: ignore[assignment]
+    instance: _MT | None  # type: ignore[assignment]
 
     class Meta:
         model: type[_MT]  # type: ignore

--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -192,7 +192,6 @@ class ModelSerializer(Serializer[_MT]):
     serializer_url_field: type[RelatedField]
     serializer_choice_field: type[Field]
     url_field_name: str | None
-    instance: _MT | None
 
     class Meta:
         model: type[_MT]  # type: ignore


### PR DESCRIPTION
fixes https://github.com/typeddjango/djangorestframework-stubs/issues/718

### Edit by @intgr

The background of this change is described in #827. If this change caused a regression in your use case, please comment there ➔ #827
