### PR TITLE
Fix CI with new mypy version

### DIFF
--- a/rest_framework-stubs/authtoken/models.pyi
+++ b/rest_framework-stubs/authtoken/models.pyi
@@ -14,5 +14,5 @@ class Token(models.Model):
 
 class TokenProxy(Token):
     # This is how drf defines this:
-    @property  # type: ignore
-    def pk(self) -> Any: ...
+    @property  
+    def pk(self) -> Any: ...  # type: ignore[override]

--- a/rest_framework-stubs/authtoken/models.pyi
+++ b/rest_framework-stubs/authtoken/models.pyi
@@ -14,5 +14,5 @@ class Token(models.Model):
 
 class TokenProxy(Token):
     # This is how drf defines this:
-    @property
+    @property  # type: ignore
     def pk(self) -> Any: ...  # type: ignore[override]

--- a/rest_framework-stubs/authtoken/models.pyi
+++ b/rest_framework-stubs/authtoken/models.pyi
@@ -14,5 +14,5 @@ class Token(models.Model):
 
 class TokenProxy(Token):
     # This is how drf defines this:
-    @property  
+    @property
     def pk(self) -> Any: ...  # type: ignore[override]


### PR DESCRIPTION
It used to be:

```

Run mypy --cache-dir=/dev/null --no-incremental rest_framework-stubs
rest_framework-stubs/authtoken/models.pyi:18: error: Cannot override writeable attribute with read-only property
Found 1 error in 1 file (checked 68 source files)
```