### PR TITLE
Added missing wsgi_request to the _MonkeyPatchedResponse

### DIFF
--- a/rest_framework-stubs/response.pyi
+++ b/rest_framework-stubs/response.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from typing import Any
 
+from django.core.handlers import WSGIRequest
 from django.template.base import Template
 from django.template.response import SimpleTemplateResponse
 from django.test.utils import ContextList
@@ -38,6 +39,7 @@ class _MonkeyPatchedResponse(Response):
     context: ContextList | dict[str, Any]
     redirect_chain: list[tuple[str, int]]
     request: dict[str, Any]
+    wsgi_request: WSGIRequest
     resolver_match: ResolverMatch
     templates: list[Template]
     def json(self) -> Any: ...

--- a/rest_framework-stubs/response.pyi
+++ b/rest_framework-stubs/response.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 from typing import Any
 
-from django.core.handlers import WSGIRequest
+from django.core.handlers.wsgi import WSGIRequest
 from django.template.base import Template
 from django.template.response import SimpleTemplateResponse
 from django.test.utils import ContextList


### PR DESCRIPTION
# I have made things!
This fixes the missing attribute in the test client responses to obtain the `wsgi_request`. This attribute is often used when using serializers that require the request context (for example, serializers with FileFields).

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Related issues
- Closes #389

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
