### PR TITLE
Restrict setuptools version to <79.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
+          pip install -U pip "setuptools<79.0.0" wheel
           SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
       - name: Run mypy on plugin code
         run: mypy --strict mypy_drf_plugin
@@ -61,7 +61,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
+          pip install -U pip "setuptools<79.0.0" wheel
           SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 
       - name: Run tests
@@ -87,7 +87,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pip setuptools wheel
+          pip install -U pip "setuptools<79.0.0" wheel
           SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -r ./requirements.txt
 
       - name: Run stubtest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,4 @@ split-on-trailing-comma = false
 extra-standard-library = ["_typeshed"]
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools<79.0.0", "wheel"]


### PR DESCRIPTION
setuptools v79.0.0 removed support for `legacy-editable` installs, causing CI to fail.

This was fixed in django-stubs by restricting the setuptools version to <79.0.0 (see https://github.com/typeddjango/django-stubs/pull/2617, thanks @michalpokusa). This PR applies the same fix.
