### PR TITLE
Tests: Fix compatbility with mypy 1.17 due to bump in django-stubs

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,7 +13,6 @@ disallow_incomplete_defs = true
 disable_error_code = empty-body
 # TODO: update our test error messages to match new mypy output
 show_error_codes = false
-force_uppercase_builtins = true
 force_union_syntax = true
 
 plugins =

--- a/tests/typecheck/test_decorators.yml
+++ b/tests/typecheck/test_decorators.yml
@@ -27,13 +27,13 @@
     main: |
         from rest_framework.decorators import api_view
         from rest_framework.request import Request
-        @api_view()  # E: Value of type variable "_RESP" of function cannot be "List[Any]"
+        @api_view()  # E: Value of type variable "_RESP" of function cannot be "list[Any]"
         def view_func2(request: Request) -> list: ...
 
 -   case: permission_classes
     main: |
         from rest_framework.decorators import permission_classes
-        reveal_type(permission_classes) # N: Revealed type is "def (permission_classes: typing.Sequence[Union[Type[rest_framework.permissions.BasePermission], rest_framework.permissions.OperandHolder, rest_framework.permissions.SingleOperandHolder]]) -> def [_View <: def (*Any, **Any) -> django.http.response.HttpResponseBase] (_View`-1) -> _View`-1"
+        reveal_type(permission_classes) # N: Revealed type is "def (permission_classes: typing.Sequence[Union[type[rest_framework.permissions.BasePermission], rest_framework.permissions.OperandHolder, rest_framework.permissions.SingleOperandHolder]]) -> def [_View <: def (*Any, **Any) -> django.http.response.HttpResponseBase] (_View`-1) -> _View`-1"
 
 -   case: permission_classes_with_operators
     main: |

--- a/tests/typecheck/test_exceptions.yml
+++ b/tests/typecheck/test_exceptions.yml
@@ -46,5 +46,5 @@
     APIException()
     APIException(None, None)
     APIException(1)  # E: Argument 1 to "APIException" has incompatible type "int"; expected "_APIExceptionInput"
-    APIException({'a': 1})  # E: Dict entry 0 has incompatible type "str": "int"; expected "str": "Union[_StrPromise, Sequence[_APIExceptionInput], Mapping[str, _APIExceptionInput], None]"
-    APIException({'a': ['test', 1]})  # E: List item 1 has incompatible type "int"; expected "Union[_StrPromise, Sequence[_APIExceptionInput], Mapping[str, _APIExceptionInput], None]"
+    APIException({'a': 1})  # E: Argument 1 to "APIException" has incompatible type "dict[str, int]"; expected "_APIExceptionInput"
+    APIException({'a': ['test', 1]})  # E: Argument 1 to "APIException" has incompatible type "dict[str, list[Union[str, int]]]"; expected "_APIExceptionInput"

--- a/tests/typecheck/test_fields.yml
+++ b/tests/typecheck/test_fields.yml
@@ -52,7 +52,7 @@
 
         CharField(initial='', default=lambda: '')
         CharField(initial=None, default=4)  # E: Argument "default" to "CharField" has incompatible type "int"; expected "Union[Union[str, _StrPromise], Callable[[], Union[str, _StrPromise]], _Empty, None]"
-        CharField(initial={}, default=empty)  # E: Argument "initial" to "CharField" has incompatible type "Dict[Never, Never]"; expected "Union[str, Callable[[], str], _Empty, None]"
+        CharField(initial={}, default=empty)  # E: Argument "initial" to "CharField" has incompatible type "dict[Never, Never]"; expected "Union[str, Callable[[], str], _Empty, None]"
 
         x: Optional[str] = CharField().get_initial()
         y: Optional[int] = CharField().get_initial()  # E: Incompatible types in assignment (expression has type "Optional[str]", variable has type "Optional[int]")
@@ -80,23 +80,23 @@
 
 -   case: MultipleChoiceField_default
     main: |
-        from typing import Set, Union
+        from typing import Union
         from rest_framework.fields import MultipleChoiceField
 
-        def int_set_callback() -> Set[int]: ...
-        def mixed_set_callback() -> Set[Union[int, str]]: ...
+        def int_set_callback() -> set[int]: ...
+        def mixed_set_callback() -> set[Union[int, str]]: ...
 
         MultipleChoiceField(choices=[1], default={1})
         MultipleChoiceField(choices=['test'], allow_null=True, default=None)
         MultipleChoiceField(choices=[1], default=int_set_callback)
         MultipleChoiceField(choices=[1, 'lulz'], default=mixed_set_callback)
-        MultipleChoiceField(choices=[1], default=lambda: [1])   # E: Argument "default" to "MultipleChoiceField" has incompatible type "Callable[[], List[int]]"; expected "Union[Set[Union[str, int]], Set[str], Set[int], Callable[[], Union[Set[Union[str, int]], Set[str], Set[int]]], _Empty, None]" # E: Incompatible return value type (got "List[int]", expected "Union[Set[Union[str, int]], Set[str], Set[int]]")
+        MultipleChoiceField(choices=[1], default=lambda: [1])   # E: Argument "default" to "MultipleChoiceField" has incompatible type "Callable[[], list[int]]"; expected "Union[set[Union[str, int]], set[str], set[int], Callable[[], Union[set[Union[str, int]], set[str], set[int]]], _Empty, None]" # E: Incompatible return value type (got "list[int]", expected "Union[set[Union[str, int]], set[str], set[int]]")
 
         MultipleChoiceField(choices=[(1, "1"), (2, "2")], default={1})
-        MultipleChoiceField(choices=[(1, "1"), (2, "2")], default=[1])  # E: Argument "default" to "MultipleChoiceField" has incompatible type "List[int]"; expected "Union[Set[Union[str, int]], Set[str], Set[int], Callable[[], Union[Set[Union[str, int]], Set[str], Set[int]]], _Empty, None]"
+        MultipleChoiceField(choices=[(1, "1"), (2, "2")], default=[1])  # E: Argument "default" to "MultipleChoiceField" has incompatible type "list[int]"; expected "Union[set[Union[str, int]], set[str], set[int], Callable[[], Union[set[Union[str, int]], set[str], set[int]]], _Empty, None]"
 
         MultipleChoiceField(choices=[(1, "1"), (2, "2")], initial={1})
-        MultipleChoiceField(choices=[(1, "1"), (2, "2")], initial=[1])  # E: Argument "initial" to "MultipleChoiceField" has incompatible type "List[int]"; expected "Union[Set[Union[Union[str, _StrPromise], int]], Set[Union[str, _StrPromise]], Set[int], Callable[[], Union[Set[Union[Union[str, _StrPromise], int]], Set[Union[str, _StrPromise]], Set[int]]], _Empty, None]"
+        MultipleChoiceField(choices=[(1, "1"), (2, "2")], initial=[1])  # E: Argument "initial" to "MultipleChoiceField" has incompatible type "list[int]"; expected "Union[set[Union[Union[str, _StrPromise], int]], set[Union[str, _StrPromise]], set[int], Callable[[], Union[set[Union[Union[str, _StrPromise], int]], set[Union[str, _StrPromise]], set[int]]], _Empty, None]"
 
 -   case: FileField_default
     main: |
@@ -123,13 +123,13 @@
         DictField(default={})
         DictField(default={'a': 1, 'b': 2})
         DictField(default=lambda: {'a': [], 'b': 'str'})
-        DictField(default=[])  # E: Argument "default" to "DictField" has incompatible type "List[Never]"; expected "Union[Dict[Any, Any], Callable[[], Dict[Any, Any]], _Empty, None]"
+        DictField(default=[])  # E: Argument "default" to "DictField" has incompatible type "list[Never]"; expected "Union[dict[Any, Any], Callable[[], dict[Any, Any]], _Empty, None]"
 
         JSONField(allow_null=True, default=None)
         JSONField(default={})
         JSONField(default={'a': 1, 'b': 2})
         JSONField(default=lambda: {'a': [], 'b': 'str'})
-        JSONField(default=[])  # E: Argument "default" to "JSONField" has incompatible type "List[Never]"; expected "Union[Mapping[Any, Any], Callable[[], Mapping[Any, Any]], _Empty, None]"
+        JSONField(default=[])  # E: Argument "default" to "JSONField" has incompatible type "list[Never]"; expected "Union[Mapping[Any, Any], Callable[[], Mapping[Any, Any]], _Empty, None]"
 
 -   case: ListField_default
     main: |
@@ -139,4 +139,4 @@
         ListField(default=[])
         ListField(default=[0, 'one'])
         ListField(default=lambda: [])
-        ListField(default='wät')  # E: Argument "default" to "ListField" has incompatible type "str"; expected "Union[List[Any], Callable[[], List[Any]], _Empty, None]"
+        ListField(default='wät')  # E: Argument "default" to "ListField" has incompatible type "str"; expected "Union[list[Any], Callable[[], list[Any]], _Empty, None]"

--- a/tests/typecheck/test_filters.yml
+++ b/tests/typecheck/test_filters.yml
@@ -14,7 +14,7 @@
 
 -   case: django_filters
     main: |
-        from typing import Any, List
+        from typing import Any
         from rest_framework.mixins import CreateModelMixin
         from rest_framework.generics import GenericAPIView, BaseFilterProtocol
         from rest_framework.request import Request
@@ -28,7 +28,7 @@
         class MyFilterBackend:
             def filter_queryset(self, request: Request, queryset: QuerySet[MyModel], view: APIView) -> QuerySet[MyModel]:
                 pass
-            def get_schema_fields(self, view: APIView) -> List[Any]:
+            def get_schema_fields(self, view: APIView) -> list[Any]:
                 pass
             def get_schema_operation_parameters(self, view: APIView) -> Any:
                 pass

--- a/tests/typecheck/test_routers.yml
+++ b/tests/typecheck/test_routers.yml
@@ -1,6 +1,6 @@
 - case: test_router_urls
   main: |
-    from typing import List, Union
+    from typing import Union
 
     from django.urls import path, include
     from rest_framework.routers import SimpleRouter, DefaultRouter
@@ -11,7 +11,7 @@
     default = DefaultRouter()
     reveal_type(default.urls)  # N: Revealed type is "builtins.list[Union[django.urls.resolvers.URLPattern, django.urls.resolvers.URLResolver]]"
 
-    urlpatterns: List[_AnyURL] = [
+    urlpatterns: list[_AnyURL] = [
         path('api/', include(simple.urls)),
         path('api/', include((simple.urls, 'app_name'), namespace='instance_name')),
         path('default/', include(default.urls)),

--- a/tests/typecheck/test_serializers.yml
+++ b/tests/typecheck/test_serializers.yml
@@ -14,7 +14,7 @@
   main: |
     from rest_framework import serializers
 
-    reveal_type(serializers.ModelSerializer.Meta.model) # N: Revealed type is "Type[_MT?]"
+    reveal_type(serializers.ModelSerializer.Meta.model) # N: Revealed type is "type[_MT?]"
     reveal_type(serializers.ModelSerializer.Meta.fields) # N: Revealed type is "typing.Sequence[builtins.str]"
     reveal_type(serializers.ModelSerializer.Meta.read_only_fields) # N: Revealed type is "Union[typing.Sequence[builtins.str], None]"
     reveal_type(serializers.ModelSerializer.Meta.exclude) # N: Revealed type is "Union[typing.Sequence[builtins.str], None]"
@@ -25,13 +25,12 @@
   main: |
     from rest_framework import serializers
     from django.contrib.auth.models import User
-    from typing import Type
 
     class TestSerializer(serializers.ModelSerializer):
         class Meta:
           model = User
 
-    def is_meta_model(serializer: Type[serializers.ModelSerializer]) -> bool:
+    def is_meta_model(serializer: type[serializers.ModelSerializer]) -> bool:
         return bool(serializer.Meta.model)
 
     reveal_type(is_meta_model(TestSerializer)) # N: Revealed type is "builtins.bool"
@@ -106,7 +105,7 @@
     - arg: ""
       err: No overload variant of "ReturnList" matches argument type "TestSerializer"
     - arg: "[],"
-      err: No overload variant of "ReturnList" matches argument types "List[Never]", "TestSerializer"
+      err: No overload variant of "ReturnList" matches argument types "list[Never]", "TestSerializer"
   main: |
     from rest_framework import serializers
     from rest_framework.utils.serializer_helpers import ReturnList
@@ -125,7 +124,7 @@
     - arg: ""
       err: All overload variants of "ReturnList" require at least one argument
     - arg: "[]"
-      err: No overload variant of "ReturnList" matches argument type "List[Never]"
+      err: No overload variant of "ReturnList" matches argument type "list[Never]"
   main: |
     from rest_framework import serializers
     from rest_framework.utils.serializer_helpers import ReturnList
@@ -176,11 +175,11 @@
     - arg: ""
       err: No overload variant of "ReturnDict" matches argument type "TestSerializer"
     - arg: "{},"
-      err: No overload variant of "ReturnDict" matches argument types "Dict[Never, Never]", "TestSerializer"
+      err: No overload variant of "ReturnDict" matches argument types "dict[Never, Never]", "TestSerializer"
     - arg: "[],"
-      err: No overload variant of "ReturnDict" matches argument types "List[Never]", "TestSerializer"
+      err: No overload variant of "ReturnDict" matches argument types "list[Never]", "TestSerializer"
     - arg: "[('a', 'a')],"
-      err: No overload variant of "ReturnDict" matches argument types "List[Tuple[str, str]]", "TestSerializer"
+      err: No overload variant of "ReturnDict" matches argument types "list[tuple[str, str]]", "TestSerializer"
   main: |
     from rest_framework import serializers
     from rest_framework.utils.serializer_helpers import ReturnDict
@@ -195,21 +194,21 @@
     main:6: note:     def [_KT, _VT] ReturnDict(self, *, serializer: BaseSerializer[Any], **kwargs: _VT) -> ReturnDict[str, _VT]
     main:6: note:     def [_KT, _VT] ReturnDict(self, SupportsKeysAndGetItem[_KT, _VT], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[_KT, _VT]
     main:6: note:     def [_KT, _VT] ReturnDict(self, SupportsKeysAndGetItem[str, _VT], /, *, serializer: BaseSerializer[Any], **kwargs: _VT) -> ReturnDict[str, _VT]
-    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[Tuple[_KT, _VT]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[_KT, _VT]
-    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[Tuple[str, _VT]], /, *, serializer: BaseSerializer[Any], **kwargs: _VT) -> ReturnDict[str, _VT]
-    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[List[str]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[str, str]
-    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[List[bytes]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[bytes, bytes]
+    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[tuple[_KT, _VT]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[_KT, _VT]
+    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[tuple[str, _VT]], /, *, serializer: BaseSerializer[Any], **kwargs: _VT) -> ReturnDict[str, _VT]
+    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[list[str]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[str, str]
+    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[list[bytes]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[bytes, bytes]
 
 - case: test_return_dict_serializer_is_required
   parametrized:
     - arg: ""
       err: All overload variants of "ReturnDict" require at least one argument
     - arg: "{}"
-      err: No overload variant of "ReturnDict" matches argument type "Dict[Never, Never]"
+      err: No overload variant of "ReturnDict" matches argument type "dict[Never, Never]"
     - arg: "[]"
-      err: No overload variant of "ReturnDict" matches argument type "List[Never]"
+      err: No overload variant of "ReturnDict" matches argument type "list[Never]"
     - arg: "[('a', 'a')]"
-      err: No overload variant of "ReturnDict" matches argument type "List[Tuple[str, str]]"
+      err: No overload variant of "ReturnDict" matches argument type "list[tuple[str, str]]"
   main: |
     from rest_framework import serializers
     from rest_framework.utils.serializer_helpers import ReturnDict
@@ -224,7 +223,7 @@
     main:6: note:     def [_KT, _VT] ReturnDict(self, *, serializer: BaseSerializer[Any], **kwargs: _VT) -> ReturnDict[str, _VT]
     main:6: note:     def [_KT, _VT] ReturnDict(self, SupportsKeysAndGetItem[_KT, _VT], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[_KT, _VT]
     main:6: note:     def [_KT, _VT] ReturnDict(self, SupportsKeysAndGetItem[str, _VT], /, *, serializer: BaseSerializer[Any], **kwargs: _VT) -> ReturnDict[str, _VT]
-    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[Tuple[_KT, _VT]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[_KT, _VT]
-    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[Tuple[str, _VT]], /, *, serializer: BaseSerializer[Any], **kwargs: _VT) -> ReturnDict[str, _VT]
-    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[List[str]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[str, str]
-    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[List[bytes]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[bytes, bytes]
+    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[tuple[_KT, _VT]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[_KT, _VT]
+    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[tuple[str, _VT]], /, *, serializer: BaseSerializer[Any], **kwargs: _VT) -> ReturnDict[str, _VT]
+    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[list[str]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[str, str]
+    main:6: note:     def [_KT, _VT] ReturnDict(self, Iterable[list[bytes]], /, *, serializer: BaseSerializer[Any]) -> ReturnDict[bytes, bytes]

--- a/tests/typecheck/test_test.yml
+++ b/tests/typecheck/test_test.yml
@@ -16,12 +16,12 @@
 
 - case: test_testcases_client_api_urlpatterns
   main: |
-    from typing import Union, List
+    from typing import Union
     from django.urls import URLPattern, URLResolver
     from rest_framework import test, status
 
     class MyTest(test.URLPatternsTestCase):
-        urlpatterns : List[Union[URLPattern, URLResolver]] = []
+        urlpatterns : list[Union[URLPattern, URLResolver]] = []
         def test_example(self) -> None:
             reveal_type(self.client) # N: Revealed type is "django.test.client.Client"
             response = self.client.get('/', format="json")

--- a/tests/typecheck/test_views.yml
+++ b/tests/typecheck/test_views.yml
@@ -67,11 +67,9 @@
 
 - case: test_override_get_permissions
   main: |
-    from typing import List
-
     from rest_framework.viewsets import GenericViewSet
     from rest_framework.permissions import BasePermission
 
     class MyView(GenericViewSet):
-        def get_permissions(self) -> List[BasePermission]:
+        def get_permissions(self) -> list[BasePermission]:
             ...


### PR DESCRIPTION
Mypy version was bumped in django-stubs:

* https://github.com/typeddjango/django-stubs/pull/2744

The `force_uppercase_builtins` setting was deprecated in mypy 1.17. Caused test failures due to new logging.

https://mypy.readthedocs.io/en/stable/changelog.html#deprecated-flag-force-uppercase-builtins

