### PR TITLE
Updated `.pre-commit-config` and `CONTRIBUTING.MD` to latest Python v…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,5 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-default_language_version:
-  python: python3.12
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -20,8 +18,8 @@ repos:
       - id: ruff-format
 
 ci:
-    autofix_commit_msg: '[pre-commit.ci] auto fixes from pre-commit.com hooks'
-    autofix_prs: true
-    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-    autoupdate_schedule: weekly
-    submodules: false
+  autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: weekly
+  submodules: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,13 +79,12 @@ pytest
 Run `bash ./scripts/stubtest.sh` to test that stubs and sources are in-line.
 
 We have two special files to allow errors:
+
 1. `scripts/stubtest/allowlist.txt` where we store things that we really don't care about: hacks, DRF internal utility modules, things that are handled by our plugin, things that are not representable by type system, etc
 2. `scripts/stubtest/allowlist_todo.txt` where we store all errors there are right now. Basically, this is a TODO list: we need to work through this list and fix things (or move entries to real `allowlist.txt`). In the end, ideally we can remove this file
 
 You might also want to disable `incremental` mode while working on `stubtest` changes.
 This mode leads to several known problems (stubs do not show up or have strange errors).
-
-**Important**: right now we only run `stubtest` on Python 3.12 (because it is the latest released version at the moment), any other versions might generate different outputs. Any work to create per-version allowlists is welcome.
 
 ## Submission Guidelines
 
@@ -96,7 +95,6 @@ The workflow for contributions is fairly simple:
 3. make whatever changes you want to contribute.
 4. ensure your contribution does not introduce linting issues or breaks the tests by linting and testing the code.
 5. make a pull request with an adequate description.
-
 
 ## Releasing `djangorestframework-stubs`
 


### PR DESCRIPTION
# I have made things!

- Updated `.pre-commit-config.yaml` to drop  

```yaml
default_language_version:
  python: python3.12
```

as it’s redundant. `djangorestframework-stubs` uses hooks that are already compatible with the latest stable Python versions.  
Keeping this pinned was only causing issues for new contributors, since `pre-commit install` failed with a `RuntimeError` if Python 3.12 wasn’t available.  

- Updated `CONTRIBUTING.md` to drop the following line as it is redundant:  

> Important: right now we only run stubtest on Python 3.12 (because it is the latest released version at the moment), any other versions might generate different outputs. Any work to create per-version allowlists is welcome.

---

## Related issues
Closes #818
