### PR TITLE
Fix `SlugRelatedField.slug_field` type: cannot be `None`

### DIFF
--- a/rest_framework-stubs/relations.pyi
+++ b/rest_framework-stubs/relations.pyi
@@ -138,7 +138,7 @@ class SlugRelatedField(RelatedField[_MT, str, str]):
     slug_field: str
     def __init__(
         self,
-        slug_field: str | None = None,
+        slug_field: str,
         *,
         many: bool = ...,
         allow_empty: bool = ...,


### PR DESCRIPTION
# I have made things!

as written in the linked issue - `slug_field` isn't really `None`, it's only `None` as the argument to the `__init__`, but is asserted to not be `None` in the first line of the method

## Related issues

closes #207 