### PR TITLE
Configure Renovate to update `uv.lock` unpinned dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+  "dependencyDashboard": false,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["* 3-4 * * *"],
+    "automerge": true,
+    "automergeType": "branch"
+  },
+  "packageRules": [
+    {
+      "enabled": false
+    }
+  ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - "renovate/**"
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
NOTE: Duplicate PR of #832. The previous one was targeting the wrong branch - my mistake. 🤦

---

As discussed in `uv` PR -- https://github.com/typeddjango/djangorestframework-stubs/pull/797#discussion_r2377084606

* After switching to `uv` package manager, `uv.lock` pins the git commit hashes used when pulling `django-stubs`/`django-stubs-ext`. BUT: we don't want it to remain pinned -- if there's an incompatible change in upstream, we want to know of it.
* Configured Renovate to update the file daily (we'll see, maybe that's too frequent).
* If the "test" GitHub workflow passes, Renovate will auto-merge. Otherwise it will open a PR.
* Renovate automerge documentation: https://docs.renovatebot.com/key-concepts/automerge/
* Closes #834

---

* [x] A maintainer with higher privileges still needs to enable the [Renovate app](https://github.com/apps/renovate) in this repo -- I've requested it.
* [x] DON'T MERGE YET: #797 should be merged first.
