### PR TITLE
Fix Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
   },
   "packageRules": [
     {
+      "matchPackageNames": ["*"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Sorry for the noise. Fixes error from previous Renovate PR #835

> Message: packageRules[0]: Each packageRule must contain at least one match* or exclude* selector. Rule: {"enabled":false}

For future reference, the following command can be used to validate configuration locally:

```shell
npx --yes --package renovate@latest -- renovate-config-validator --strict
```
