### PR TITLE
Switch release workflow to `uv`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,14 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Setup python to build package
-        uses: actions/setup-python@v6
+      - name: Install uv & Python
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.12'
-      - name: Install build
-        run: python -m pip install build
+          python-version: "3.13"
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Build package
-        run: python -m build
+        run: uv build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ markdown = ["types-Markdown>=0.1.5"]
 
 [dependency-groups]
 dev = [
-  "wheel",
   "pre-commit==4.3.0",
   "pytest==8.4.2",
   "pytest-mypy-plugins==3.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,6 @@ dev = [
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-urllib3" },
-    { name = "wheel" },
 ]
 
 [package.metadata]
@@ -277,7 +276,6 @@ dev = [
     { name = "types-pyyaml", specifier = "==6.0.12.20250915" },
     { name = "types-requests", specifier = "==2.32.4.20250913" },
     { name = "types-urllib3", specifier = "==1.26.25.14" },
-    { name = "wheel" },
 ]
 
 [[package]]
@@ -1133,13 +1131,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
-]
-
-[[package]]
-name = "wheel"
-version = "0.45.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/98/2d9906746cdc6a6ef809ae6338005b3f21bb568bea3165cfc6a243fdc25c/wheel-0.45.1.tar.gz", hash = "sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729", size = 107545, upload-time = "2024-11-23T00:18:23.513Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl", hash = "sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248", size = 72494, upload-time = "2024-11-23T00:18:21.207Z" },
 ]


### PR DESCRIPTION
* Switching GitHub "release" workflow from PyPI [`build`](https://pypi.org/project/build/) dependency to `uv build` built-in command.
* Updated "release" workflow to Python 3.13 managed with `uv`.
* `wheel` dependency is not used any more -- removed.

#### Related issues

* #797
