### PR TITLE
Test new release workflow: version 3.16.4a1 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,15 +96,15 @@ The workflow for contributions is fairly simple:
 
 ## Releasing `djangorestframework-stubs`
 
-1. Open a pull request that updates `setup.py` (anyone can open this PR, not just maintainers):
+1. Open a pull request that updates `pyproject.toml` (anyone can open this PR, not just maintainers):
 
-   - Increase `version=` value within `setup(...)`. Version number `major.minor.patch` is formed as follows:
+   - Increase `version =` value within `[project]` section. Version number `major.minor.patch` is formed as follows:
 
      `major.minor` version must match newest supported `djangorestframework` release.
 
      `patch` is sequentially increasing for each stubs release. Reset to `0` if `major.minor` was updated.
 
-   - Update `django-stubs>=` dependency to point to latest `django-stubs` release.
+   - Under `dependencies =`, update the `django-stubs>=` version to point to latest `django-stubs` release.
    - Update lockfile, run: `uv lock`
    - Use pull request title "Version x.y.z release" by convention.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "djangorestframework-stubs"
-version = "3.16.3"
+version = "3.16.4a1"
 requires-python = ">=3.10"
 description = "PEP-484 stubs for django-rest-framework"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -210,7 +210,7 @@ wheels = [
 
 [[package]]
 name = "djangorestframework-stubs"
-version = "3.16.3"
+version = "3.16.4a1"
 source = { editable = "." }
 dependencies = [
     { name = "django-stubs" },


### PR DESCRIPTION
Using alpha version in case anything goes wrong -- so users won't be updated automatically.

* Updated "Releasing djangorestframework-stubs" documentation
* Testing #838.
