### PR TITLE
Fix Renovate 'lock file maintenance' schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "dependencyDashboard": false,
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["* 3-4 * * *"],
     "automerge": true,
     "automergeType": "branch"
   },


### PR DESCRIPTION
Turns out that the interaction between Renovate Cloud scheduling and `"schedule"` setting is confusing and poorly documented.

Using the free Renovate Cloud option, Renovate _usually_ runs once per day, at some arbitrary time. If that time does not match our defined `"schedule"`, then it does nothing. ¯\_(ツ)_/¯

By removing `"schedule"`, it should result in actually running once per day.

Some pointers:
* https://docs.renovatebot.com/key-concepts/scheduling/#global-schedule-vs-specific-schedule
* https://docs.renovatebot.com/mend-hosted/job-scheduling/#renovate-status
* https://github.com/renovatebot/renovate/discussions/35532