### PR TITLE
Fix Renovate 'lock file maintenance' schedule *again*

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "automergeType": "branch"
+    "automergeType": "branch",
+    "schedule": ["* * * * *"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
Sorry, again! Another attempt at #843

Turns out that the interaction between Renovate Cloud scheduling and `"schedule"` setting is confusing and poorly documented.

`lockFileMaintenance` has a different default schedule -- it defaults to `before 4am on monday`. Once per week is too rare IMO for our use case -- and the "before 4am" part is rarely useful with the cloud offering, because the triggering time is arbitrary during the day.

* https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
* https://github.com/renovatebot/renovate/discussions/35532#discussioncomment-14576025