### PR TITLE
Recognize many=True serializer constructors as ListSerializer

### DIFF
--- a/mypy_drf_plugin/main.py
+++ b/mypy_drf_plugin/main.py
@@ -36,7 +36,7 @@ class NewSemanalDRFPlugin(Plugin):
     @override
     def get_function_signature_hook(self, fullname: str) -> Callable[[FunctionSigContext], CallableType] | None:
         if fullname in self._get_currently_defined_serializers():
-            return serializers.add_list_serializer_kwargs_when_many
+            return serializers.transform_serializer_constructor_when_many
         return None
 
 

--- a/mypy_drf_plugin/main.py
+++ b/mypy_drf_plugin/main.py
@@ -1,7 +1,8 @@
 from collections.abc import Callable
 
 from mypy.nodes import TypeInfo
-from mypy.plugin import ClassDefContext, Plugin
+from mypy.plugin import ClassDefContext, FunctionSigContext, Plugin
+from mypy.types import CallableType
 from typing_extensions import override
 
 from mypy_drf_plugin.lib import fullnames, helpers
@@ -30,6 +31,12 @@ class NewSemanalDRFPlugin(Plugin):
     def get_base_class_hook(self, fullname: str) -> Callable[[ClassDefContext], None] | None:
         if fullname in self._get_currently_defined_serializers():
             return transform_serializer_class
+        return None
+
+    @override
+    def get_function_signature_hook(self, fullname: str) -> Callable[[FunctionSigContext], CallableType] | None:
+        if fullname in self._get_currently_defined_serializers():
+            return serializers.add_list_serializer_kwargs_when_many
         return None
 
 

--- a/mypy_drf_plugin/transformers/serializers.py
+++ b/mypy_drf_plugin/transformers/serializers.py
@@ -1,6 +1,8 @@
+from mypy.maptype import map_instance_to_supertype
 from mypy.nodes import ARG_NAMED_OPT, NameExpr
 from mypy.plugin import ClassDefContext, FunctionSigContext
 from mypy.types import AnyType, CallableType, Instance, NoneType, TypeOfAny, UnionType
+from mypy.types import Type as MypyType
 from mypy_django_plugin.lib import helpers as mypy_django_helpers
 
 from mypy_drf_plugin.lib import fullnames
@@ -22,10 +24,28 @@ def _many_is_truthy(ctx: FunctionSigContext) -> bool:
     return any(isinstance(expr, NameExpr) and expr.fullname == "builtins.True" for expr in ctx.args[many_idx])
 
 
+def _child_instance_type(sig: CallableType) -> MypyType:
+    # Walk the child serializer's MRO up to BaseSerializer[_IN] and return the
+    # bound _IN. Falls back to Any if the return type isn't a normal Instance
+    # or BaseSerializer isn't in its MRO.
+    ret = sig.ret_type
+    if not isinstance(ret, Instance):
+        return AnyType(TypeOfAny.special_form)
+    base = next((b for b in ret.type.mro if b.fullname == fullnames.BASE_SERIALIZER_FULLNAME), None)
+    if base is None or not base.type_vars:
+        return AnyType(TypeOfAny.special_form)
+    mapped = map_instance_to_supertype(ret, base)
+    if not mapped.args:
+        return AnyType(TypeOfAny.special_form)
+    return mapped.args[0]
+
+
 def transform_serializer_constructor_when_many(ctx: FunctionSigContext) -> CallableType:
     # A Serializer called with ``many=True`` is turned into a ListSerializer by
     # ``many_init`` at runtime. Reflect that by accepting ListSerializer-only
-    # kwargs (``min_length`` / ``max_length``) and returning ``ListSerializer[Any]``.
+    # kwargs (``min_length`` / ``max_length``) and returning
+    # ``ListSerializer[Iterable[_IN]]`` so that ``.instance`` keeps the
+    # element type of the child serializer.
     sig = ctx.default_signature
     if not _many_is_truthy(ctx):
         return sig
@@ -48,9 +68,11 @@ def transform_serializer_constructor_when_many(ctx: FunctionSigContext) -> Calla
         new_arg_names.append(name)
         new_arg_types.append(int_or_none)
 
+    iterable_of_child = ctx.api.named_generic_type("typing.Iterable", [_child_instance_type(sig)])
+
     return sig.copy_modified(
         arg_kinds=new_arg_kinds,
         arg_names=new_arg_names,
         arg_types=new_arg_types,
-        ret_type=Instance(list_serializer_info, [AnyType(TypeOfAny.special_form)]),
+        ret_type=Instance(list_serializer_info, [iterable_of_child]),
     )

--- a/mypy_drf_plugin/transformers/serializers.py
+++ b/mypy_drf_plugin/transformers/serializers.py
@@ -1,7 +1,9 @@
 from mypy.nodes import ARG_NAMED_OPT, NameExpr
 from mypy.plugin import ClassDefContext, FunctionSigContext
-from mypy.types import CallableType, NoneType, UnionType
+from mypy.types import AnyType, CallableType, Instance, NoneType, TypeOfAny, UnionType
 from mypy_django_plugin.lib import helpers as mypy_django_helpers
+
+from mypy_drf_plugin.lib import fullnames
 
 
 def make_meta_nested_class_inherit_from_any(ctx: ClassDefContext) -> None:
@@ -20,11 +22,18 @@ def _many_is_truthy(ctx: FunctionSigContext) -> bool:
     return any(isinstance(expr, NameExpr) and expr.fullname == "builtins.True" for expr in ctx.args[many_idx])
 
 
-def add_list_serializer_kwargs_when_many(ctx: FunctionSigContext) -> CallableType:
-    # When a Serializer is instantiated with ``many=True`` it becomes a
-    # ListSerializer at runtime, which accepts ``min_length`` / ``max_length``.
+def transform_serializer_constructor_when_many(ctx: FunctionSigContext) -> CallableType:
+    # A Serializer called with ``many=True`` is turned into a ListSerializer by
+    # ``many_init`` at runtime. Reflect that by accepting ListSerializer-only
+    # kwargs (``min_length`` / ``max_length``) and returning ``ListSerializer[Any]``.
     sig = ctx.default_signature
     if not _many_is_truthy(ctx):
+        return sig
+
+    list_serializer_info = mypy_django_helpers.lookup_fully_qualified_typeinfo(
+        ctx.api, fullnames.LIST_SERIALIZER_FULLNAME
+    )
+    if list_serializer_info is None:
         return sig
 
     int_or_none = UnionType([ctx.api.named_generic_type("builtins.int", []), NoneType()])
@@ -43,4 +52,5 @@ def add_list_serializer_kwargs_when_many(ctx: FunctionSigContext) -> CallableTyp
         arg_kinds=new_arg_kinds,
         arg_names=new_arg_names,
         arg_types=new_arg_types,
+        ret_type=Instance(list_serializer_info, [AnyType(TypeOfAny.special_form)]),
     )

--- a/mypy_drf_plugin/transformers/serializers.py
+++ b/mypy_drf_plugin/transformers/serializers.py
@@ -1,4 +1,6 @@
-from mypy.plugin import ClassDefContext
+from mypy.nodes import ARG_NAMED_OPT, NameExpr
+from mypy.plugin import ClassDefContext, FunctionSigContext
+from mypy.types import CallableType, NoneType, UnionType
 from mypy_django_plugin.lib import helpers as mypy_django_helpers
 
 
@@ -7,3 +9,38 @@ def make_meta_nested_class_inherit_from_any(ctx: ClassDefContext) -> None:
     if meta_node is None:
         return None
     meta_node.fallback_to_any = True
+
+
+def _many_is_truthy(ctx: FunctionSigContext) -> bool:
+    sig = ctx.default_signature
+    try:
+        many_idx = sig.arg_names.index("many")
+    except ValueError:
+        return False
+    return any(isinstance(expr, NameExpr) and expr.fullname == "builtins.True" for expr in ctx.args[many_idx])
+
+
+def add_list_serializer_kwargs_when_many(ctx: FunctionSigContext) -> CallableType:
+    # When a Serializer is instantiated with ``many=True`` it becomes a
+    # ListSerializer at runtime, which accepts ``min_length`` / ``max_length``.
+    sig = ctx.default_signature
+    if not _many_is_truthy(ctx):
+        return sig
+
+    int_or_none = UnionType([ctx.api.named_generic_type("builtins.int", []), NoneType()])
+
+    new_arg_kinds = list(sig.arg_kinds)
+    new_arg_names: list[str | None] = list(sig.arg_names)
+    new_arg_types = list(sig.arg_types)
+    for name in ("min_length", "max_length"):
+        if name in sig.arg_names:
+            continue
+        new_arg_kinds.append(ARG_NAMED_OPT)
+        new_arg_names.append(name)
+        new_arg_types.append(int_or_none)
+
+    return sig.copy_modified(
+        arg_kinds=new_arg_kinds,
+        arg_names=new_arg_names,
+        arg_types=new_arg_types,
+    )

--- a/tests/typecheck/test_serializers.yml
+++ b/tests/typecheck/test_serializers.yml
@@ -1,3 +1,26 @@
+- case: test_serializer_many_accepts_list_serializer_kwargs
+  main: |
+    from rest_framework import serializers
+
+    class ChildSerializer(serializers.Serializer):
+        pass
+
+    ChildSerializer(many=True, min_length=1)
+    ChildSerializer(many=True, max_length=5)
+    ChildSerializer(many=True, allow_empty=False, min_length=1, max_length=5)
+
+- case: test_serializer_without_many_rejects_list_serializer_kwargs
+  main: |
+    from rest_framework import serializers
+
+    class ChildSerializer(serializers.Serializer):
+        pass
+
+    ChildSerializer(min_length=1)
+  out: |
+    main:6: error: Unexpected keyword argument "min_length" for "ChildSerializer"  [call-arg]
+    main:6: note: "ChildSerializer" defined in "rest_framework.serializers"
+
 - case: test_return_list_serializer_argument_is_kw_only
   parametrized:
     - arg: ""

--- a/tests/typecheck/test_serializers.yml
+++ b/tests/typecheck/test_serializers.yml
@@ -1,3 +1,32 @@
+- case: test_serializer_with_many_returns_list_serializer
+  main: |
+    from typing import Any
+    from typing_extensions import assert_type
+    from rest_framework import serializers
+    from rest_framework.utils.serializer_helpers import ReturnList
+
+    class ChildSerializer(serializers.Serializer):
+        pass
+
+    s = ChildSerializer(many=True)
+    assert_type(s, serializers.ListSerializer[Any])
+    assert_type(s.data, ReturnList[Any])
+    assert_type(s.to_representation([]), list[Any])
+
+- case: test_serializer_without_many_is_not_list_serializer
+  main: |
+    from typing import Any
+    from typing_extensions import assert_type
+    from rest_framework import serializers
+    from rest_framework.utils.serializer_helpers import ReturnDict
+
+    class ChildSerializer(serializers.Serializer):
+        pass
+
+    s = ChildSerializer()
+    assert_type(s, ChildSerializer)
+    assert_type(s.data, ReturnDict[Any, Any])
+
 - case: test_serializer_many_accepts_list_serializer_kwargs
   main: |
     from rest_framework import serializers

--- a/tests/typecheck/test_serializers.yml
+++ b/tests/typecheck/test_serializers.yml
@@ -1,5 +1,6 @@
 - case: test_serializer_with_many_returns_list_serializer
   main: |
+    from collections.abc import Iterable
     from typing import Any
     from typing_extensions import assert_type
     from rest_framework import serializers
@@ -9,9 +10,25 @@
         pass
 
     s = ChildSerializer(many=True)
-    assert_type(s, serializers.ListSerializer[Any])
+    assert_type(s, serializers.ListSerializer[Iterable[Any]])
     assert_type(s.data, ReturnList[Any])
     assert_type(s.to_representation([]), list[Any])
+
+- case: test_generic_serializer_with_many_preserves_instance_element_type
+  main: |
+    from collections.abc import Iterable
+    from typing_extensions import assert_type
+    from rest_framework import serializers
+
+    class Item:
+        pass
+
+    class ItemSerializer(serializers.Serializer[Item]):
+        pass
+
+    s = ItemSerializer(many=True)
+    assert_type(s, serializers.ListSerializer[Iterable[Item]])
+    assert_type(s.instance, Iterable[Item] | None)
 
 - case: test_serializer_without_many_is_not_list_serializer
   main: |


### PR DESCRIPTION
# I have made things!

At runtime, `SomeSerializer(many=True, ...)` is swapped for a ListSerializer via `many_init`, but the stubs type it as the original serializer, so valid calls are rejected and downstream attributes lie about their types.

 This adds a `get_function_signature_hook` on every registered serializer class that, when many=True is literally passed:

  - accepts the ListSerializer-only kwargs min_length and max_length;
  - rewrites the constructor's return type to ListSerializer[Collection[_IN]], extracting _IN by mapping the child serializer's instance to BaseSerializer in its MRO.