### PR TITLE
Fix `ManyRelatedField` type parameters & relation field `default`/`initial` types

### DIFF
--- a/rest_framework-stubs/relations.pyi
+++ b/rest_framework-stubs/relations.pyi
@@ -168,7 +168,7 @@ class SlugRelatedField(RelatedField[_MT, str, str]):
     @override
     def to_representation(self, obj: _MT | PKOnlyObject) -> str: ...
 
-class ManyRelatedField(Field[Iterable[Any], Iterable[Any], list[Any], Any]):
+class ManyRelatedField(Field[Iterable[Any], Sequence[Any], list[Any], Any]):
     html_cutoff: int | None
     html_cutoff_text: str | None
     child_relation: RelatedField

--- a/rest_framework-stubs/relations.pyi
+++ b/rest_framework-stubs/relations.pyi
@@ -3,7 +3,7 @@ from typing import Any, Self, TypeVar
 
 from django.db.models import Manager, Model, QuerySet
 from django_stubs_ext import StrOrPromise
-from rest_framework.fields import Field, Option
+from rest_framework.fields import Field, Option, _DefaultInitial
 from rest_framework.request import Request
 from rest_framework.validators import Validator
 from typing_extensions import override
@@ -153,8 +153,8 @@ class SlugRelatedField(RelatedField[_MT, str, str]):
         read_only: bool = ...,
         write_only: bool = ...,
         required: bool | None = None,
-        default: _DT = ...,
-        initial: _MT | Callable[[Any], _MT] = ...,
+        default: _DefaultInitial[_MT] = ...,
+        initial: _DefaultInitial[_MT] = ...,
         source: str | None = None,
         label: StrOrPromise | None = ...,
         help_text: StrOrPromise | None = None,
@@ -168,13 +168,12 @@ class SlugRelatedField(RelatedField[_MT, str, str]):
     @override
     def to_representation(self, obj: _MT | PKOnlyObject) -> str: ...
 
-class ManyRelatedField(Field[Sequence[Any], Sequence[Any], list[Any], Any]):
-    default_empty_html: list[object]
+class ManyRelatedField(Field[Iterable[Any], Iterable[Any], list[Any], Any]):
     html_cutoff: int | None
     html_cutoff_text: str | None
     child_relation: RelatedField
     allow_empty: bool
-    initial: list[Any]
+    initial: Any
     def __init__(
         self,
         # DISCREPANCY: signature defaults `child_relation=None`, but actually crashes when `None` is provided.
@@ -183,14 +182,14 @@ class ManyRelatedField(Field[Sequence[Any], Sequence[Any], list[Any], Any]):
         read_only: bool = ...,
         write_only: bool = ...,
         required: bool | None = None,
-        default: Sequence[Any] = ...,
-        initial: Sequence[Any] | Callable[[Any], Sequence[Any]] = ...,
+        default: _DefaultInitial[Iterable[Any]] = ...,
+        initial: _DefaultInitial[Iterable[Any]] = ...,
         source: str | None = None,
         label: StrOrPromise | None = ...,
         help_text: str | None = ...,
-        style: dict[str, str] | None = ...,
+        style: dict[str, Any] | None = ...,
         error_messages: dict[str, StrOrPromise] | None = ...,
-        validators: Sequence[Validator[Sequence[Any]]] | None = ...,
+        validators: Sequence[Validator[Iterable[Any]]] | None = ...,
         allow_null: bool = ...,
         allow_empty: bool = ...,
     ) -> None: ...

--- a/tests/assert_type/serializers.py
+++ b/tests/assert_type/serializers.py
@@ -1,7 +1,7 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, TypedDict, assert_type, cast
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.utils.functional import cached_property
 from rest_framework import serializers
 from rest_framework.relations import PKOnlyObject
@@ -81,6 +81,16 @@ assert_type(pk_field_typed.pk_field, serializers.Field | None)
 field = serializers.SlugRelatedField(slug_field="username", queryset=User.objects.all())
 obj = PKOnlyObject(pk=1)
 assert_type(field.to_representation(obj), str)
+
+# case: many_related_field_value_type_iterable
+child_relation = serializers.PrimaryKeyRelatedField(queryset=Group.objects.all())
+groups_qs = Group.objects.all()
+many_field = serializers.ManyRelatedField(
+    child_relation=child_relation, read_only=True, default=groups_qs, initial=groups_qs
+)
+user = cast("User", object())
+value = many_field.get_attribute(user)
+assert_type(value, Iterable[Any] | None)
 
 
 # case: test_hyperlinked_model_serializer_with_customized_serializer_field_mapping


### PR DESCRIPTION
Aligns with base `Field` class.

`ManyRelatedField` was declared with `Sequence[Any]` for the value type parameters, but DRF accepts any non-str iterable in `to_internal_value`/`to_representation`, and `get_attribute` returns `relationship.all()`. django-stubs declares `QuerySet` as `Iterable` (not `Sequence`), so a `QuerySet` value was rejected by mypy. Widen both to `Iterable[Any]`.

- Type `default`/`initial` as `_DefaultInitial[...]` to match the base `Field`
- Fix `SlugRelatedField` `default` (was `_DT`, the data type) and `initial` to `_DefaultInitial[_MT]`
- Align `validators`/`style` annotations with the base `Field`
- Drop the now-redundant `to_representation` override and the inaccurate `default_empty_html`/`initial` attribute overrides (inherited from `Field`)
- Add assert_type test passing a `QuerySet` as `default`/`initial`

## Related issues

- Fixes #1045
- Closes https://github.com/typeddjango/djangorestframework-stubs/pull/1048
